### PR TITLE
Networking setup for xps 15 9560

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -120,7 +120,8 @@
       enableFccUnlock = true;
       wifi.backend = "iwd";
     };
-    
+    nameservers = [ "1.1.1.1" "8.8.8.8" "9.9.9.9" ];
+    firewall.enable = true;
   };
 
   time.timeZone = "America/Los_Angeles";


### PR DESCRIPTION
- feat: move from wpa_supplicant to iwd, its more stable and faster to connect.
- fix: feat: reenable network manager.
- feat: Enable firewall and add systemwide dns servers.
