### PR TITLE
FEAT: onedrive: bringup.

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -182,6 +182,11 @@
     joinNetworks = [ "565799d8f65ab6a3" ];
   };
 
+  services.onedrive = {
+    enable = true;
+    package = pkgs.unstable.onedrive;
+  };
+
   services.udev = {
     extraRules = ''
       # Remove NVIDIA USB xHCI Host Controller devices, if present


### PR DESCRIPTION
* Needs auth before being useful, this will install the software though.
* Will need to also tie into a couple of files for onedrive-launcher services.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
