### PR TITLE
FIX: swap not mounting, mount the correct boot partition.

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -82,6 +82,10 @@ in {
     options nouveau modeset=0
   '';
 
+  # Make sure swap gets unlocked.
+  boot.initrd.luks.devices."swap".device =
+    "/dev/disk/by-uuid/c20f4b7d-5f67-4f24-b796-c6d1446ecd26";
+
   kernel-mod.ntfs3.enable = true;
   nixpkgs = {
     overlays = [

--- a/nixos/hardware-configuration.nix
+++ b/nixos/hardware-configuration.nix
@@ -29,14 +29,6 @@
     "/dev/disk/by-uuid/b704b36a-9b78-488f-b8c2-3f910a4e7883";
 
   fileSystems."/boot" = {
-    device = "/dev/disk/by-uuid/96039c89-b897-4fcc-ac0e-b4999c433db1";
-    fsType = "ext4";
-  };
-
-  boot.initrd.luks.devices."boot".device =
-    "/dev/disk/by-uuid/80ab3ae5-b400-4f73-b302-5d8590de6538";
-
-  fileSystems."/boot/EFI" = {
     device = "/dev/disk/by-uuid/26E4-630A";
     fsType = "vfat";
   };


### PR DESCRIPTION
* swap was overwritten by a previous generation, make sure its permanent.
* Boot partition *needs* to be fat32 in nixos, not just /boot/EFI. Previous configuration used a broken up structure which mean when a reconfiguration happened it would pick up the stray /boot parition. Solved on the hardware/parition end. Make sure it is also configured correctly here.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
