### PR TITLE
FEAT: usbip: add to kernel modules.

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -39,10 +39,10 @@ in {
     ddcci-driver
     # enable temp monitoring subsystem
     tmon
-    # enable zfs
+    # enable zfs (still broken in 6.2.x)
     # zfs
     # usb over ip
-    # usbip
+    usbip
     # processor stats
     turbostat
   ];


### PR DESCRIPTION
Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
