### PR TITLE
FEAT: kitty: init config.

### DIFF
--- a/features/hm/kitty/default.nix
+++ b/features/hm/kitty/default.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  imports = [];
+  options = {};
+  config = {
+    nixpkgs = {
+      overlay = [
+        (final: prev: { kitty-themes = pkgs.unstable.kitty-themes; } )
+      ];
+    };
+    programs = {
+      kitty = {
+        enable = true;
+        package = pkgs.unstable.kitty;
+        theme  = "Gruvbox Material Dark Hard";
+      };
+    };
+  };
+}

--- a/hm/home.nix
+++ b/hm/home.nix
@@ -9,6 +9,7 @@ in {
     ../features/auth/hm-gpg/yubikey.nix
     ../features/hm/kanshi
     ../features/hm/zsh
+    ../features/hm/kitty
   ];
   nixpkgs = {
     overlays = [ ];


### PR DESCRIPTION
* Need an overlay to track both kitty and kitty-themes as unstable.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
