### PR TITLE
FEAT: kitty: init config.

### DIFF
--- a/features/hm/kitty/default.nix
+++ b/features/hm/kitty/default.nix
@@ -1,18 +1,16 @@
-{ pkgs, ... }:
-{
-  imports = [];
-  options = {};
+{ pkgs, ... }: {
+  imports = [ ];
+  options = { };
   config = {
     nixpkgs = {
-      overlay = [
-        (final: prev: { kitty-themes = pkgs.unstable.kitty-themes; } )
-      ];
+      overlay =
+        [ (final: prev: { kitty-themes = pkgs.unstable.kitty-themes; }) ];
     };
     programs = {
       kitty = {
         enable = true;
         package = pkgs.unstable.kitty;
-        theme  = "Gruvbox Material Dark Hard";
+        theme = "Gruvbox Material Dark Hard";
       };
     };
   };


### PR DESCRIPTION
* Need an overlay to track both kitty and kitty-themes as unstable.
NOTE: Second try since the first pr was already merged, need to include the formatting fixes.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
