### PR TITLE
FIX: kitty: misspelling.

### DIFF
--- a/features/hm/kitty/default.nix
+++ b/features/hm/kitty/default.nix
@@ -3,7 +3,7 @@
   options = { };
   config = {
     nixpkgs = {
-      overlay =
+      overlays =
         [ (final: prev: { kitty-themes = pkgs.unstable.kitty-themes; }) ];
     };
     programs = {


### PR DESCRIPTION
Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
