### PR TITLE
FIX: gpg: PR did not include the rename in the imports for home.nix, fix.

### DIFF
--- a/hm/home.nix
+++ b/hm/home.nix
@@ -6,7 +6,7 @@ in {
   imports = [
     inputs.hyprland.homeManagerModules.default
     inputs.spicetify.homeManagerModule
-    ../features/auth/hm-gpg/yubikey.nix
+    ../features/hm/gpg
     ../features/hm/kanshi
     ../features/hm/zsh
     ../features/hm/kitty


### PR DESCRIPTION
Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
