### PR TITLE
FIX: nixos: fix misspelling.

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -154,7 +154,7 @@
       wifi.backend = "iwd";
     };
     nameservers = [ "1.1.1.1" "8.8.8.8" "9.9.9.9" ];
-    firewal = {
+    firewall = {
       enable = true;
       allowedTCPPortRanges = [
         # kdeconnect


### PR DESCRIPTION
Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
