### PR TITLE
FEAT/nixos/yubikey u2f

### DIFF
--- a/features/nixos/auth/yubikey/yubikey.nix
+++ b/features/nixos/auth/yubikey/yubikey.nix
@@ -6,7 +6,7 @@ let
     "michael:DhrurLkHDQCpgSdzh7CPgMNgb+tQ2uDh/5WqixOldGr75ixKMNohH4l+TXghK66MetkjHKxF/iCm6t9Jb2N6rA==,3FHox1tsrKjs3HGn4RWNXvwWiXW0M9kgY0zC2r2fJy7Q9squKei6mvrUfkMzCAWzmmiIKjjZjKmMF5BtxgyswA==,es256,+presence:wgLH6pLDQwlL/RbQnT/CtMuSFn7VH14qQLqkex1t9VsZRCcUMqaaiyqEjsmdAOxuXp9QBKZIXFLAhs/9McmZJQ==,+1u7ifuqoxjSIlCrY7vzF5uI1uhWiNGE39kv0tjjk+PoozygIQHi2CIB4hUDv9WXTPcJk4MhGiFSwGgwSecmhA==,es256,+presence:afjG830wh8QnGsZmb8raLQ5CP3RvXVyKhZBK1e8p8JHvcZHjrIkE8xQifHkjmKqTFL58EUGtePhotzfo9pjOaw==,9hyR6kqSYa3B1nNzpDywlzLVlKXFsEGNbx212VhS34IijOsQTX0o8NQkk+5Q/amQR/hS1UsRcTMx2Q/sxWgGfg==,es256,+presence:6JSCUKfEYEfv7lh4SUTfcrbaxmjD6DnlBMyD25z8MVuO1f9fQaKiaPKTxOtD8u2gUibi4tRUcj8BuUFiwumGhA==,UD90YpoXfGvHcjYBieOWcBmTp5IGoYbpsIAmcjE5chGFDAskKjCXLpxYilwKl7R/ZL9z9uUUqUuFmtdESB4eag==,es256,+presence";
 
   u2f_file = pkgs.writeText "u2f_mapping" u2f_keys;
-  graphical = config.xdg.portal.enable;
+  graphical = true;
   greetdEnabled = config.services.greetd.enable;
 in {
   imports = [ ../pam/pam-u2f.nix ];

--- a/features/nixos/auth/yubikey/yubikey.nix
+++ b/features/nixos/auth/yubikey/yubikey.nix
@@ -6,7 +6,7 @@ let
     "michael:DhrurLkHDQCpgSdzh7CPgMNgb+tQ2uDh/5WqixOldGr75ixKMNohH4l+TXghK66MetkjHKxF/iCm6t9Jb2N6rA==,3FHox1tsrKjs3HGn4RWNXvwWiXW0M9kgY0zC2r2fJy7Q9squKei6mvrUfkMzCAWzmmiIKjjZjKmMF5BtxgyswA==,es256,+presence:wgLH6pLDQwlL/RbQnT/CtMuSFn7VH14qQLqkex1t9VsZRCcUMqaaiyqEjsmdAOxuXp9QBKZIXFLAhs/9McmZJQ==,+1u7ifuqoxjSIlCrY7vzF5uI1uhWiNGE39kv0tjjk+PoozygIQHi2CIB4hUDv9WXTPcJk4MhGiFSwGgwSecmhA==,es256,+presence:afjG830wh8QnGsZmb8raLQ5CP3RvXVyKhZBK1e8p8JHvcZHjrIkE8xQifHkjmKqTFL58EUGtePhotzfo9pjOaw==,9hyR6kqSYa3B1nNzpDywlzLVlKXFsEGNbx212VhS34IijOsQTX0o8NQkk+5Q/amQR/hS1UsRcTMx2Q/sxWgGfg==,es256,+presence:6JSCUKfEYEfv7lh4SUTfcrbaxmjD6DnlBMyD25z8MVuO1f9fQaKiaPKTxOtD8u2gUibi4tRUcj8BuUFiwumGhA==,UD90YpoXfGvHcjYBieOWcBmTp5IGoYbpsIAmcjE5chGFDAskKjCXLpxYilwKl7R/ZL9z9uUUqUuFmtdESB4eag==,es256,+presence";
 
   u2f_file = pkgs.writeText "u2f_mapping" u2f_keys;
-  graphical = true;
+  graphical = config.gtk.enable;
   greetdEnabled = config.services.greetd.enable;
 in {
   imports = [ ../pam/pam-u2f.nix ];


### PR DESCRIPTION
- FEAT: change graphical boolean from xdg. * xdg can be enabled but a graphical desktop can be disabled.
- FIX: nixos/yubikey_u2f: adjust to use gtk.enable instead of static bool.
