### PR TITLE
FIX: nixos: add devMachine property.

### DIFF
--- a/features/nixos/common/default.nix
+++ b/features/nixos/common/default.nix
@@ -2,7 +2,7 @@
   imports = [ ];
   options = {
     audio.enable = lib.mkEnableOption "Installs common audio apps.";
-    graphical.enable = lib.mkEnableOption "Install common graphical apps.";
+    devMachine.enable = lib.mkEnableOption "Install common developer apps.";
   };
   config = {
     environment.systemPackages = with pkgs;
@@ -21,9 +21,9 @@
         viu
         neofetch
         thefuck
-        nixfmt
         powertop
         pciutils
+        usbutils
         # extract 
         unzip
         zip
@@ -36,49 +36,21 @@
         lz4
         unrar-wrapper
         rpm
-
         neovim
         nvd
-
+        btop
+        unstable.home-manager
       ]
       ++ lib.optionals (config.audio.enable) [ pavucontrol ncpamixer playerctl ]
-      ++ lib.optionals (config.graphical.enable) [
-        nmap # network visualizer
-        keepassxc # pass
-        # telegram
-        tdesktop
-        kotatogram-desktop
-        # discord
-        unstable.webcord
-        # vnc
-        unstable.wayvnc
-        remmina
-        unstable.kanshi
-        nyxt
+      ++ lib.optionals (config.devMachine.enable) [
+        nix-prefetch
+        nix-prefetch-git
+        nix-prefetch-github
+        nix-index
+        nixfmt
+        # csv files in terminal
+        tidy-viewer
       ];
   };
 }
-# mako notifications
-# nmap
-# mplayer
-# tidy-viewer # csv printer terminal
-# pavucontrol # audio
-# ncpamixer # audio
-# keepassxc # graphical
-# tg # terminal but only for michael user
-# tdesktop # graphical
-# kotatogram-desktop
-# playerctl # audio
-# waybar-hyprland
-# unstable-webcord
-# slackterm
-# themechanger
-# brightnessctl #
-# unstable.wayvnc # vnc
-# remmina # vnc
-# unstable.nil # nvim nix lsp michael user
-# gsettings-qt
-#     inputs.nwg-displays-pkgs.packages.${pkgs.system}.nwg-displays
-# unstable.kanshi # screen control
-# nyxt # vim/emacs browser
 

--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -22,6 +22,7 @@
     ../../features/nixos/logitech
     ../../features/nixos/login
     ../../features/nixos/desktop
+    ../../features/nixos/common
   ];
   boot.initrd.availableKernelModules = [
     # fast decrypt for luks
@@ -84,6 +85,8 @@
     "/dev/disk/by-uuid/c20f4b7d-5f67-4f24-b796-c6d1446ecd26";
 
   kernel-mod.ntfs3.enable = true;
+  audio.enable = true;
+  devMachine.enable = true;
   nixpkgs = {
     overlays = [
       # overlay skeleton


### PR DESCRIPTION
* remove graphical apps, they are now set in wayland folder
* include a devMachine property that installs nix specific dev tools for
  now.
* enable config in nyx.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
