### PR TITLE
FIX: make sure dunst service depends on xdg service.

### DIFF
--- a/features/nixos/desktop/wayland/default.nix
+++ b/features/nixos/desktop/wayland/default.nix
@@ -24,11 +24,9 @@ in {
         [ "https://nixpkgs-wayland.cachix.org" "https://hyprland.cachix.org" ];
     };
     nixpkgs.overlays = [
-      (final: prev: {
-        waybar = nw.waybar;
-      })
+      (final: prev: { waybar = nw.waybar; })
 
-     ];
+    ];
 
     programs.hyprland = {
       enable = true;
@@ -127,7 +125,9 @@ in {
       ## wayland pip video player (not part of the nix community wayland repo) but added here for wayland only config
       qt-video-wlr
     ];
-
+    systemd.user.units."dunst" = {
+      wantedBy = [ "xdg-desktop-portal.service" ];
+    };
   };
 
 }


### PR DESCRIPTION
* Formatting fixes as well.

This fixes dunst starting and crashing.

NOTE: might change it to depend on XDPH although XDP is more universal.
Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
