### PR TITLE
FEAT: enable service switching for home manager when activating the generation.

### DIFF
--- a/hm/home.nix
+++ b/hm/home.nix
@@ -79,6 +79,8 @@ in {
     ];
 
   };
+  # Nicely reload system units when changing configs
+  systemd.user.startServices = "sd-switch";
   # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
   home.stateVersion = "23.05";
 }


### PR DESCRIPTION
Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
