### PR TITLE
FEAT: pc: nyx: Disable fingerpring reader.

### DIFF
--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -224,6 +224,8 @@
       ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{power/control}="auto", ATTR{remove}="1"
       # Remove NVIDIA VGA/3D controller devices
       ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", ATTR{power/control}="auto", ATTR{remove}="1"
+      # Disable fingerprint reader
+      SUBSYSTEM=="usb", ATTRS{idVendor}=="27c6", ATTRS{idProduct}=="5395", ATTR{authorized}="0"
     '';
   };
 


### PR DESCRIPTION
* Not usuable currently, disable it.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
