### PR TITLE
FEAT: nixos: nyx: change to 6.1 kernel.

### DIFF
--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -71,11 +71,12 @@
     "mitigations=off"
   ];
 
-  boot.kernelPackages = pkgs.linuxPackages_6_2;
+  boot.kernelPackages = pkgs.linuxPackages_6_1;
   # taken from disable nvidia
   boot.extraModprobeConfig = ''
     blacklist nouveau
     options nouveau modeset=0
+
   '';
 
   # Make sure swap gets unlocked.


### PR DESCRIPTION
* when remote builing 6.2 got weird bpf message which are attributed to modules not being compiled along with the kernel, stick to kernel already compiled for now.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
