### PR TITLE
FEAT: dunst: make sure service starts correctly.

### DIFF
--- a/features/nixos/desktop/wayland/default.nix
+++ b/features/nixos/desktop/wayland/default.nix
@@ -126,7 +126,7 @@ in {
       qt-video-wlr
     ];
     systemd.user.units."dunst" = {
-      wantedBy = [ "xdg-desktop-portal.service" ];
+      wantedBy = [ "graphical-session.target" ];
     };
   };
 


### PR DESCRIPTION
* This is universal, should work both in wayland and x11.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
