### PR TITLE
PC: nyx: getting kernel panics debug.

### DIFF
--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -32,13 +32,14 @@
   ];
   # make sure to compile broadcom kernel modules, needed for the bcm4360
   boot.kernelModules = [ "wl" ];
-  boot.extraModulePackages = with config.boot.kernelPackages; [
-    broadcom_sta
-    # to control brightness on non-internal monitors
-    ddcci-driver
-    # enable zfs (still broken in 6.2.x)
-    # zfs
-  ];
+  boot.extraModulePackages = with config.boot.kernelPackages;
+    [
+      broadcom_sta
+      # to control brightness on non-internal monitors
+      # ddcci-driver
+      #  enable zfs (still broken in 6.2.x)
+      # zfs
+    ];
   boot.blacklistedKernelModules = [ "b43" "bcma" ];
 
   boot.loader = {
@@ -51,22 +52,20 @@
   services.fwupd.enable = true;
   boot.kernelParams = [
     # from: https://wiki.archlinux.org/title/Dell_XPS_15_(9560)#Enable_power_saving_features_for_the_i915_kernel_module
-    "i915.enable_psr=1"
-    "i915.enable_fbc=1"
-    "i915.disable_power_well=0"
+    #"i915.enable_psr=1"
+    #"i915.enable_fbc=1"
+    #"i915.disable_power_well=0"
     # Make sure the laptop exposes correct acpi. Makes the laptop less crash prone
     "acpi_rev_override=1"
-    # define that we are linux
-    "acpi_osi=Linux"
-    # lets see the battery savings with this
-    "pcie_aspm=on"
+    # let tlp handle this part
+    "pcie_aspm=off"
     # USB-C fix, do not sleep the pcie links
     #"pcie_aspm=off"
     # "pcie_port_pm=off"
     # Do not let nouveau take control of the nvidia gpu
     "nouveau.modeset=0"
     # Test option, to see if there is any discernible difference
-    "workqueue.power_efficient=1"
+    #"workqueue.power_efficient=1"
     # Self explanatory
     "mitigations=off"
   ];


### PR DESCRIPTION
* disable i915 options
* linux osi should not be set, delete.
* disbale power_efficient workqueues, did not see much of a difference.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
