### PR TITLE
FEAT: kanshi: fix service.

### DIFF
--- a/features/hm/kanshi/default.nix
+++ b/features/hm/kanshi/default.nix
@@ -1,13 +1,18 @@
-{ inputs, pkgs, ... }:
+{ inputs, pkgs, config, ... }:
 let nw = inputs.nixpkgs-wayland.packages.${pkgs.system};
 in {
   imports = [ ];
   options = { };
   config = {
     services = {
-      kanshi = {
+      kanshi = let
+        # TODO: include sway and newm commands as well
+        hyprctl =
+          "${config.wayland.windowManager.hyprland.package}/bin/hyprctl";
+      in {
         enable = true;
         package = nw.kanshi;
+        systemdTarget = "graphical-session.target";
         profiles = {
           default-setup = {
             outputs = [{
@@ -21,7 +26,7 @@ in {
           };
           mobile-with-monitor = {
             # This does the 90 deg rotation since kanshi cannot do it on its own
-            exec = [ "hyprctl keyword monitor DP-1, transform,1" ];
+            exec = [ "${hyprctl} keyword monitor DP-1, transform,1" ];
             outputs = [
               {
                 # 4k display from xps 9560

--- a/features/hm/wayland/hyprland.conf
+++ b/features/hm/wayland/hyprland.conf
@@ -18,7 +18,7 @@
 #monitor=,highres,auto,1.5
 exec=xprop -root -f _XWAYLAND_GLOBAL_OUTPUT_SCALE 32c -set _XWAYLAND_GLOBAL_OUTPUT_SCALE 2
 env = XCURSOR_SIZE,24
-exec-once=kanshi
+#exec-once=kanshi
 
 
 
@@ -85,7 +85,7 @@ decoration {
     blur_passes = 1
     blur_new_optimizations = true
 
-    drop_shadow = true
+    drop_shadow = false
     shadow_range = 4
     shadow_render_power = 3
     col.shadow = rgba(1a1a1aee)


### PR DESCRIPTION
* Service was by default tied to sway, change this to graphical session. This does mean that if i were to install a DE it might interfere, for now keep as is.

* Now that kanshi is a service, change command to use the location of the actual command instead of the command directly, since the running the context is different.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
