### PR TITLE
FEAT/nixos/add deploy platform

### DIFF
--- a/features/nixos/common/default.nix
+++ b/features/nixos/common/default.nix
@@ -1,5 +1,5 @@
 { config, pkgs, lib, inputs, ... }: {
-  imports = [ ];
+  imports = [ ./deploy.nix ];
   options = {
     audio.enable = lib.mkEnableOption "Installs common audio apps.";
     devMachine.enable = lib.mkEnableOption "Install common developer apps.";

--- a/features/nixos/common/deploy.nix
+++ b/features/nixos/common/deploy.nix
@@ -1,0 +1,42 @@
+{ pkgs, ... }: {
+  users.groups.deploy = { };
+  users.users.deploy = {
+    isSystemUser = true;
+    group = "deploy";
+    shell = pkgs.bash;
+
+    openssh.authorizedKeys.keys = [
+      "no-pty sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAICFSUN6IGskLmeq7ip+oTbYuE+WRLcbYGGGOAyH/ECWaAAAABHNzaDo= michael@nyx"
+      "no-pty sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIAKEnIsOFEp1Lx9XwZRVN+iRKyCKRiy4U9kw1JWH1UAYAAAABHNzaDo= michael@nyx"
+      "no-pty "
+      "no-pty "
+    ];
+  };
+
+  security.sudo.extraRules = [{
+    groups = [ "deploy" ];
+    commands = [
+      {
+        command = "/nix/store/*/bin/switch-to-configuration";
+        options = [ "NOPASSWD" ];
+      }
+      {
+        command = "/run/current-system/sw/bin/nix-store";
+        options = [ "NOPASSWD" ];
+      }
+      {
+        command = "/run/current-system/sw/bin/nix-env";
+        options = [ "NOPASSWD" ];
+      }
+      {
+        command = ''
+          /bin/sh -c "readlink -e /nix/var/nix/profiles/system || readlink -e /run/current-system"'';
+        options = [ "NOPASSWD" ];
+      }
+      {
+        command = "/run/current-system/sw/bin/nix-collect-garbage";
+        options = [ "NOPASSWD" ];
+      }
+    ];
+  }];
+}

--- a/nixos/kore/configuration.nix
+++ b/nixos/kore/configuration.nix
@@ -7,6 +7,8 @@ let fsOptions = [ "compress=zstd" "noatime" ];
 in {
   imports = [ # Include the results of the hardware scan.
     ./hardware-configuration.nix
+    ../../features/nixos/common
+    ../../features/nixos/kernel
   ];
 
   # Use the systemd-boot EFI boot loader.


### PR DESCRIPTION
- FEAT: nixos: deploy.nix: add deploy user.
- PC: kore: add kernel and common apps.
