### PR TITLE
PC: kore: add common hardware config options.

### DIFF
--- a/nixos/kore/configuration.nix
+++ b/nixos/kore/configuration.nix
@@ -6,6 +6,12 @@
 let fsOptions = [ "compress=zstd" "noatime" ];
 in {
   imports = [ # Include the results of the hardware scan.
+    inputs.hardware.nixosModules.common-cpu-amd
+    inputs.hardware.nixosModules.common-cpu-amd-pstate
+    inputs.hardware.nixosModules.common-pc
+    { services.xserver.libinput.enable = lib.mkForce false; }
+    inputs.hardware.nixosModules.common-pc-hdd
+    inputs.hardware.nixosModules.common-pc-ssd
     ./hardware-configuration.nix
     ../../features/nixos/common
     ../../features/nixos/kernel


### PR DESCRIPTION
* the cpu amd options will make a big difference once the system moves to  >=5.17 kernel.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
