### PR TITLE
FEAT/nixos/virt init

### DIFF
--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -29,7 +29,11 @@ in {
       libvirtd = {
         enable = true;
         qemu = {
-          ovmf.enable = true;
+          ovmf = {
+            enable = true;
+            packages =
+              [ pkgs.OVMFFull.fd pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd ];
+          };
           swtpm = { enable = true; };
         };
       };

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -1,0 +1,40 @@
+{ pkgs, config, lib, ... }:
+let
+  intel = builtins.elem "kvm-intel" config.boot.kernelModules;
+  amd = builtins.elem "kvm-amd" config.boot.kernelModules;
+  cfg = config;
+in {
+  options = { vfio.enable = lib.mkEnableOption "Configure for vfio."; };
+
+  config = lib.mkIf (cfg.vfio.enable) {
+    boot = {
+      initrd.kernelModules =
+        [ "vfio" "vfio_pci" "vfio_iommu_type1" "vfio_virqfd" ];
+
+      kernelParams = lib.optionals (amd) [
+        "amd_iommu=on"
+        "kvm_amd.npt=1"
+        "kvm_amd.avic=1"
+        "kvm_amd.nested=1"
+        "kvm.ignore_msrs=1"
+        "kvm.report_ignored_msrs=0"
+      ] ++ lib.optionals (intel) [
+        # TODO: other options?
+        "kvm_intel.nested=1"
+      ];
+    };
+    virtualisation = {
+      # as understood, since this will be headless and with no x11/wayland, ths will be unneeded
+
+      libvirtd = {
+        enable = true;
+        qemu = {
+          ovmf.enable = true;
+          swtpm = { enable = true; };
+        };
+      };
+    };
+    environment.systemPackages = with pkgs; [ libvirt qemu OVMFFull pciutils ];
+  };
+}
+

--- a/nixos/kore/configuration.nix
+++ b/nixos/kore/configuration.nix
@@ -15,9 +15,10 @@ in {
     ./hardware-configuration.nix
     ../../features/nixos/common
     ../../features/nixos/kernel
+    ../../features/nixos/virtualization
     ../../features/nixos/common/deploy.nix
   ];
-
+  vfio.enable = true;
   # Use the systemd-boot EFI boot loader.
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = false;


### PR DESCRIPTION
- FEAT: nixos: virt: initial config.
- FEAT: nixos: virt: add arm64 ovmf.
- NIXOS: kore: add virt feature and enable it.
