### PR TITLE
FIX/nixos/vfio blackscreen fix

### DIFF
--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -18,6 +18,7 @@ in {
         "kvm_amd.nested=1"
         "kvm.ignore_msrs=1"
         "kvm.report_ignored_msrs=0"
+        "tsc=nowatchdog"
       ] ++ lib.optionals (intel) [
         # TODO: other options?
         "kvm_intel.nested=1"

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -35,6 +35,9 @@ in {
             packages =
               [ pkgs.OVMFFull.fd pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd ];
           };
+          swtpm = {
+            enable = true;
+          };
           swtpm = { enable = true; };
         };
       };

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -35,7 +35,7 @@ in {
           ovmf = {
             enable = true;
             packages =
-              [ pkgs.OVMFFull.fd pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd ];
+              [ pkgs.OVMF.fd pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd ];
           };
           swtpm = {
             enable = true;

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -14,7 +14,7 @@ in {
       kernelParams = lib.optionals (amd) [
         "amd_iommu=on"
         "kvm_amd.npt=1"
-        "kvm_amd.avic=1"
+        #"kvm_amd.avic=1"
         "kvm_amd.nested=1"
         "kvm.ignore_msrs=1"
         "kvm.report_ignored_msrs=0"

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -29,6 +29,7 @@ in {
 
       libvirtd = {
         enable = true;
+        allowedBridges = [ "br-vm" ];
         package = pkgs.unstable.libvirt;
         qemu = {
           package = pkgs.unstable.qemu;

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -35,8 +35,12 @@ in {
           package = pkgs.unstable.qemu;
           ovmf = {
             enable = true;
-            packages =
-              [ pkgs.OVMF.fd pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd ];
+            packages = [
+              # NOTE: OVMFFull DOES NOT WORK ON MY SYSTEM FOR SOME REASON < DEBUG ASAP
+              # VM WONT BOOT WITH CSM ENABLED
+              (pkgs.unstable.OVMFFull.override { csmSupport = false; }).fd
+              pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd
+            ];
           };
           swtpm = {
             enable = true;

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -22,7 +22,7 @@ in {
       ] ++ lib.optionals (intel) [
         # TODO: other options?
         "kvm_intel.nested=1"
-      ];
+      ] ++ [ "vfio-pci.ids=10de:1e82,10de:10f8,10de:1ad8,10de:1ad9" ];
     };
     virtualisation = {
       # as understood, since this will be headless and with no x11/wayland, ths will be unneeded

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -44,7 +44,7 @@ in {
         };
       };
     };
-    environment.systemPackages = with pkgs; [ libvirt qemu OVMFFull pciutils ];
+    environment.systemPackages = with pkgs; [ pciutils virt-manager ];
   };
 }
 

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -29,7 +29,9 @@ in {
 
       libvirtd = {
         enable = true;
+        package = pkgs.unstable.libvirt;
         qemu = {
+          package = pkgs.unstable.qemu;
           ovmf = {
             enable = true;
             packages =


### PR DESCRIPTION
- FIX: test if avic is the problem
- FIX: check if tsc is being disabled accounts for slow boot boot time.
- FIX: check if tsc is being disabled accounts for slow boot boot time.
- FIX: Enable TPM, since old config expects it.
- FIX: See if switching to lastest qemu and libvirt fixes it.
- FIX: remove qemu and ovmf from install list. They are already defined in the options--date=2023-05-23T06:40:00-0700
- FIX: OVMF is the culprit, move to minimal pkg.
- Make sure we specify that the bridge is allowed and vm is able to connect.
- FIX: found reason OVMFFull does not work and workaround.
