### PR TITLE
FEAT/virt/fixes 1

### DIFF
--- a/features/nixos/virtualization/amd-noflr.patch
+++ b/features/nixos/virtualization/amd-noflr.patch
@@ -1,0 +1,23 @@
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index b7347bc6a24d..5ad877fd49d8 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -5017,6 +5017,17 @@ int pci_dev_specific_disable_acs_redir(struct pci_dev *dev)
+        return -ENOTTY;
+ }
+ 
++/*
++ * Ryzen 3rd-gen CPU-provided USB and audio advertise FLR, but invoking it hangs.
++ * NOTE: Not true for chipset-provided USB which has the same ID.
++ */
++static void quirk_amd_no_flr(struct pci_dev *dev)
++{
++       dev->dev_flags |= PCI_DEV_FLAGS_NO_FLR_RESET;
++}
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMD, 0x149c, quirk_amd_no_flr);
++DECLARE_PCI_FIXUP_EARLY(PCI_VENDOR_ID_AMD, 0x1487, quirk_amd_no_flr);
++
+ /*
+  * The PCI capabilities list for Intel DH895xCC VFs (device ID 0x0443) with
+  * QuickAssist Technology (QAT) is prematurely terminated in hardware.  The
+

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -41,6 +41,7 @@ in {
             packages = [
               # NOTE: OVMFFull DOES NOT WORK ON MY SYSTEM FOR SOME REASON < DEBUG ASAP
               # VM WONT BOOT WITH CSM ENABLED
+              # TODO: seperate fd's for all the options, or at least have the ability to use qemu's images for this
               (pkgs.unstable.OVMFFull.override { csmSupport = false; }).fd
               pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd
             ];
@@ -54,6 +55,16 @@ in {
     };
     environment.systemPackages = with pkgs; [ pciutils virt-manager ];
 
+    environment.etc = {
+      "ovmf/edk2-x86_64-secure-code.fd" = {
+        source =
+          "${cfg.virtualisation.libvirtd.qemu.package}/share/qemu/edk2-x86_64-secure-code.fd";
+      };
+      "ovmf/edk2-i386-vars.fd" = {
+        source =
+          "${cfg.virtualisation.libvirtd.qemu.package}/share/qemu/edk2-i386-vars.fd";
+      };
+    };
     boot.kernelPatches = lib.optionals cfg.kernel.patch.sm.enable [
       {
         name = "SM2622en flr workaround";

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -4,7 +4,11 @@ let
   amd = builtins.elem "kvm-amd" config.boot.kernelModules;
   cfg = config;
 in {
-  options = { vfio.enable = lib.mkEnableOption "Configure for vfio."; };
+  options = {
+    vfio.enable = lib.mkEnableOption "Configure for vfio.";
+    kernel.patch.sm.enable = lib.mkEnableOption
+      "Kernel patch to workaround faulty FLR for Sillicon Motion nvme controllers.";
+  };
 
   config = lib.mkIf (cfg.vfio.enable) {
     boot = {
@@ -46,6 +50,13 @@ in {
       };
     };
     environment.systemPackages = with pkgs; [ pciutils virt-manager ];
+
+    boot.kernelPatches = lib.optionals cfg.kernel.patch.sm.enable [
+      {
+        name = "SM2622en flr workaround";
+        patch = ./sm2262-nvme-subsystem-reset.diff;
+      }
+    ];
   };
 }
 

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -45,7 +45,10 @@ in {
               pkgs.pkgsCross.aarch64-multiplatform.OVMF.fd
             ];
           };
-          swtpm = { enable = true; };
+          swtpm = {
+            enable = true;
+            package = pkgs.unstable.swtpm;
+          };
         };
       };
     };

--- a/features/nixos/virtualization/default.nix
+++ b/features/nixos/virtualization/default.nix
@@ -59,6 +59,10 @@ in {
         name = "SM2622en flr workaround";
         patch = ./sm2262-nvme-subsystem-reset.diff;
       }
+      {
+        name = "amd-noflr";
+        patch = ./amd-noflr.patch;
+      }
     ];
   };
 }

--- a/features/nixos/virtualization/sm2262-nvme-subsystem-reset.diff
+++ b/features/nixos/virtualization/sm2262-nvme-subsystem-reset.diff
@@ -1,0 +1,71 @@
+diff --git a/drivers/pci/pci.c b/drivers/pci/pci.c
+index 3d2fb394986a..68d3041766fc 100644
+--- a/drivers/pci/pci.c
++++ b/drivers/pci/pci.c
+@@ -5054,7 +5054,7 @@ int pci_bridge_secondary_bus_reset(struct pci_dev *dev)
+ }
+ EXPORT_SYMBOL_GPL(pci_bridge_secondary_bus_reset);
+ 
+-static int pci_parent_bus_reset(struct pci_dev *dev, bool probe)
++int pci_parent_bus_reset(struct pci_dev *dev, bool probe)
+ {
+ 	struct pci_dev *pdev;
+ 
+diff --git a/drivers/pci/pci.h b/drivers/pci/pci.h
+index 3d60cabde1a1..499b3877e1fe 100644
+--- a/drivers/pci/pci.h
++++ b/drivers/pci/pci.h
+@@ -36,6 +36,7 @@ int pci_mmap_fits(struct pci_dev *pdev, int resno, struct vm_area_struct *vmai,
+ bool pci_reset_supported(struct pci_dev *dev);
+ void pci_init_reset_methods(struct pci_dev *dev);
+ int pci_bridge_secondary_bus_reset(struct pci_dev *dev);
++int pci_parent_bus_reset(struct pci_dev *dev, bool probe);
+ int pci_bus_error_reset(struct pci_dev *dev);
+ 
+ struct pci_cap_saved_data {
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 20a932690738..3148f795d2fe 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -4036,6 +4036,30 @@ static int reset_hinic_vf_dev(struct pci_dev *pdev, bool probe)
+ 	return 0;
+ }
+ 
++/*
++ * The Silicon Motion SM2262 is an NVMe controller used by several vendors
++ * which is know to corrupt its MSI-X capability after FLR (PBA offset from
++ * the vector table only allows for 16 entries (0x100 offset) but after FLR
++ * the MSI-X capability reports 22 entries).  As this is a single function
++ * device, a bus reset should offer no significant loss of functionality
++ * versus FLR on this device.  Downstream ports blacklisting bus reset via
++ * PCI_DEV_FLAGS_NO_BUS_RESET will fall back to FLR as we have no workaround
++ * for them.
++ *
++ * Link: https://bugzilla.kernel.org/show_bug.cgi?id=202055
++ *
++ * This controller is known to be used in the Intel 760p (8086:f1a6) and
++ * ADATA XPG SX8200 (126f:2262), the latter making use of the native PCI
++ * vendor and device ID from Silicon Motion.  Also believed to be affected
++ * are the Mushkin Pilot, HP EX920, and Western Digital Black, though it's
++ * not known if any of these override the native device ID as Intel does.
++ */
++static int prefer_bus_reset(struct pci_dev *dev, bool probe)
++{
++	return pci_parent_bus_reset(dev, probe);
++}
++
++
+ static const struct pci_dev_reset_methods pci_dev_reset_methods[] = {
+ 	{ PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_82599_SFP_VF,
+ 		 reset_intel_82599_sfp_virtfn },
+@@ -4046,6 +4070,9 @@ static const struct pci_dev_reset_methods pci_dev_reset_methods[] = {
+ 	{ PCI_VENDOR_ID_SAMSUNG, 0xa804, nvme_disable_and_flr },
+ 	{ PCI_VENDOR_ID_INTEL, 0x0953, delay_250ms_after_flr },
+ 	{ PCI_VENDOR_ID_INTEL, 0x0a54, delay_250ms_after_flr },
++	{ 0x126f, 0x2262, prefer_bus_reset },
++	{ 0x126f, 0x2263, prefer_bus_reset },
++	{ PCI_VENDOR_ID_INTEL, 0xf1a6, prefer_bus_reset },
+ 	{ PCI_VENDOR_ID_CHELSIO, PCI_ANY_ID,
+ 		reset_chelsio_generic_dev },
+ 	{ PCI_VENDOR_ID_HUAWEI, PCI_DEVICE_ID_HINIC_VF,
+


### PR DESCRIPTION
- FIX: add workaround for sm2262en chips not resetting cleanly.
- VIRT: switch swtpm to unstable package.
- VIRT: add amd noflr patch
- VIRT: ovmf: See if qemu's ovmf will allow for secure boot.
