### PR TITLE
FEAT: shinake fixes to config.

### DIFF
--- a/features/hm/wayland/default.nix
+++ b/features/hm/wayland/default.nix
@@ -1,6 +1,4 @@
-{ config, lib, pkgs, inputs, ... }:
-let nw = inputs.nixpkgs-wayland.packages.${pkgs.system};
-in {
+{ config, lib, pkgs, ... }: {
   imports = [ ./swayidle.nix ];
   config = {
     wayland.windowManager.hyprland = {
@@ -70,7 +68,7 @@ in {
           Documentation = [ "man:shikane(1)" "man:shikane(5)" ];
         } // unitRules;
         Service = {
-          ExecStart = "${lib.getExe pkgs.shikane}";
+          ExecStart = "${lib.getExe pkgs.unstable.shikane}";
           Type = "simple";
           Restart = "always";
           Environment = [
@@ -101,7 +99,8 @@ in {
         enable = true;
         source = ./waybar;
       };
-      configFile."shikane/config.toml".source = ../shikane/config.toml;
+      configFile."shikane/config.toml".text =
+        import ../shikane/config.toml.nix { inherit config lib pkgs; };
     };
     services.dunst = {
       enable = true;


### PR DESCRIPTION
* make sure to update to use text instead of source: since the function returns text and not a file.
* change to use the unstable version of nixpkgs, since shikane is already committed, and the package nix is not alread removed from this repo.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
