### PR TITLE
HOTFIX: Fix home manager not working with 22.11 nixpkgs lib.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,14 @@
     nixpkgs = { url = "nixpkgs/nixos-22.11"; };
     nixpkgs-unstable = { url = "nixpkgs/nixos-unstable"; };
     home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
+      # TODO: Decide whether to either to move on using 23.05 (once it gets stable) or revert back to hm-22.11 or the hackiest
+      # way, overlay the file with one from unstable.
+      # it will probably be easier to move to 23.05 as there are some options that are not avaible in the hm-22.11 branch.
+      # For now, stick to a revsion before the breaking change. This should not be a problem since following an unstable channel
+      # should give the required function with the right arguments (unless misunderstood).
+      url =
+        "github:nix-community/home-manager/6a1922568337e7cf21175213d3aafd1ac79c9a2e";
+      inputs.nixpkgs.follows = "/nixpkgs-unstable";
     };
     hardware = { url = "github:nixos/nixos-hardware/master"; };
 


### PR DESCRIPTION
* Follow home-manager to the point that the breaking change happened.
* This means that home-manager input is now 'frozen' temporarily, until
  a better solution is decided upon.
* Options are ( from cleanest to hackiest):
  * Stick to rev until rev 22.11 of nixpkgs picks up the change.
  * If 22.11 does not pick up the change or if it comes out of beta,
    switch to 23.05 (currently in beta as mentioned).
  * Revert to 22.11 of home manager. This does mean that there are some
    breaking changes, where some options are not avaible
    (as they were introduced after 22.11). Means more time tracking
    and rewriting code.
  * Force home-manager to use nixpkgs lib from unstable. I assumed that
    by setting the follows to nixpkgs-unstable (as set in flake.nix)
    that it would pick up unstable. This is not the case. Would need to
    investigate further. Ideally this would be best scenario, but
    because of the time invested, it will probaly be the most time
    intensive.
  * Overlay nixpkgs lib that home manager uses. This is by far the
    hackiest solution since it overrides just that file with the lib
    that contains the new code. This is very fragile since it is prone
    to breaking, not to mention the maintence cost having to do with
    maintaing a seperate file that is overlayed in lib.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
