### PR TITLE
FEAT/nixos/kernel options 1

### DIFF
--- a/features/nixos/kernel/default.nix
+++ b/features/nixos/kernel/default.nix
@@ -1,10 +1,21 @@
-{ lib, ... }: {
-  imports = [ ./ntfs.nix ];
+{ lib, pkgs, config, ... }:
+let kernel = config.kernel.mod.kernelPkg;
+in {
+  imports = [ ./ntfs.nix ./native.nix ];
   options = {
-    kernel-mod = {
-      ntfs3 = {
-        enable = lib.mkEnableOption "compiles ntfs3 support in the kernel";
+    kernel = {
+      mod = with lib; {
+        kernelPkg = mkOption {
+          description = "kernel being used";
+          type = with types; raw;
+          default = pkgs.linuxPackages;
+        };
+        ntfs.enable = mkEnableOption "compiles ntfs3 support in the kernel";
+        native.enable = mkEnableOption "compiles with native build flags.";
       };
     };
   };
+  # since this is not defined in the config, set a default config when importing the module
+  # TODO: Find a better way of setting this in code.
+  config = { boot.kernelPackages = lib.mkDefault kernel; };
 }

--- a/features/nixos/kernel/native.nix
+++ b/features/nixos/kernel/native.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+let cfg = config;
+in {
+  config = lib.mkIf (cfg.kernel.mod.native.enable) {
+    nixpkgs.overlays = [
+      (final: prev: {
+        linux-kernel = final.linuxPackagesFor
+          (cfg.kernel.mod.kernelPkg.override {
+            extraMakeFlags = [ "-march=native" "-mtune=native" "-flto" ];
+          });
+      })
+    ];
+    boot.kernelPackages = pkgs.linux-kernel;
+  };
+}

--- a/features/nixos/kernel/ntfs.nix
+++ b/features/nixos/kernel/ntfs.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, config, ... }:
-let kernel-mod = config.kernel-mod;
+let kernel-mod = config.kernel.mod;
 in {
 
-  config = lib.mkIf kernel-mod.ntfs3.enable {
+  config = lib.mkIf kernel-mod.ntfs.enable {
     nixpkgs.overlays = [
       (self: super: {
         linuxPackages_6_2 = pkgs.linuxPackagesFor


### PR DESCRIPTION
- FEAT: add native config, when the option is enabled, this will compile the linux kernel with native flags and lto
- FEAT: add plugin native module and set boot.kernelPackages.
- FEAT: kernel: ntfs: redo.
