### PR TITLE
FEAT/hm/ssh add endpoints 1

### DIFF
--- a/features/hm/ssh/default.nix
+++ b/features/hm/ssh/default.nix
@@ -40,6 +40,12 @@ in {
               PreferredAuthentications = "publickey";
             };
           };
+          # in-progress
+          "rescue@khaos" = mkHost {
+            hostname = "172.30.0.20";
+            user = "root";
+            port = 2222;
+          };
           "charon" = mkHost {
             hostname = "172.30.0.8";
             user = "root";
@@ -58,12 +64,6 @@ in {
           };
           # aarch64 master node prev known as atlas
           "hades" = mkHost { hostname = "172.30.0.4"; };
-          # in-progress
-          "khaos-rescue" = mkHost {
-            hostname = "172.30.0.20";
-            user = "root";
-            port = 2222;
-          };
         };
       };
     };

--- a/features/hm/ssh/default.nix
+++ b/features/hm/ssh/default.nix
@@ -46,14 +46,15 @@ in {
             user = "root";
             port = 2222;
           };
+          # kvm
           "charon" = mkHost {
             hostname = "172.30.0.8";
             user = "root";
           };
           # local ryzen server prev known as zeus
-          # local ip is 192.168.5
+          # local ip is 192.168.1.5
           "kore" = mkHost { hostname = "172.30.0.5"; };
-          "kore-decrypt" = mkHost {
+          "decrypt@kore" = mkHost {
             hostname = "192.168.1.5";
             user = "root";
             port = 2222;

--- a/features/hm/ssh/default.nix
+++ b/features/hm/ssh/default.nix
@@ -65,6 +65,8 @@ in {
           };
           # aarch64 master node prev known as atlas
           "hades" = mkHost { hostname = "172.30.0.4"; };
+          # vm: local ip is 192.168.1.8
+          "odin" = mkHost { hostname = "172.30.0.11"; };
         };
       };
     };


### PR DESCRIPTION
- FEAT: hm: ssh-config: reconfigure and move khaos rescue.
- FEAT: hm: ssh-config: rename decrypt to conform to the rest of the config.
- FEAT: hm: ssh-config: add new endpoint odin.
