### PR TITLE
FEAT/hm/fix dunst 1

### DIFF
--- a/features/hm/wayland/default.nix
+++ b/features/hm/wayland/default.nix
@@ -115,9 +115,7 @@
     };
     services.dunst = {
       enable = true;
-      package = nw.dunst;
-
+      package = pkgs.unstable.dunst;
     };
-
   };
 }

--- a/features/hm/wayland/default.nix
+++ b/features/hm/wayland/default.nix
@@ -86,6 +86,9 @@
         };
         Install = { WantedBy = wantedRule; };
       };
+      # for later reading
+      # https://pychao.com/2021/02/24/difference-between-partof-and-bindsto-in-a-systemd-unit/
+      dunst = { Unit = unitRules; };
     };
     dconf.settings = {
       #"org/gnome/desktop/interface" = {


### PR DESCRIPTION
- FEAT: hm: wayland: dunst: change service rules to reflect use in hyprland.
- FEAT: hm: wayland: dunst: switch installed package to the unstable nixpkgs release.
