### PR TITLE
FEAT/kitty scrollback

### DIFF
--- a/features/hm/kitty/default.nix
+++ b/features/hm/kitty/default.nix
@@ -17,7 +17,7 @@
           size = 9;
         };
         settings = {
-          scrollback_lines = 10000;
+          scrollback_lines = 100000;
           enable_audio_bell = true;
           bold_font = "JetBrains Mono Bold Nerd Font Complete";
           italic_font = "JetBrains Mono SemiBold Italic Nerd Font Complete";

--- a/features/nixos/desktop/common/default.nix
+++ b/features/nixos/desktop/common/default.nix
@@ -53,6 +53,8 @@ in {
         keepassxc
         # telegram
         tdesktop
+        # the package below still uses openssl 1.1.x, until 
+        # https://github.com/NixOS/nixpkgs/pull/234359 gets merged, keep commented out.
         #kotatogram-desktop
 
         # vnc

--- a/features/nixos/desktop/common/default.nix
+++ b/features/nixos/desktop/common/default.nix
@@ -53,7 +53,7 @@ in {
         keepassxc
         # telegram
         tdesktop
-        kotatogram-desktop
+        #kotatogram-desktop
 
         # vnc
         unstable.wayvnc

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = " Nix infrastructure config";
 
   inputs = {
-    nixpkgs = { url = "nixpkgs/nixos-22.11"; };
+    nixpkgs = { url = "nixpkgs/nixos-23.05"; };
     nixpkgs-unstable = { url = "nixpkgs/nixos-unstable"; };
     home-manager = {
       # TODO: Decide whether to either to move on using 23.05 (once it gets stable) or revert back to hm-22.11 or the hackiest
@@ -11,8 +11,9 @@
       # For now, stick to a revsion before the breaking change. This should not be a problem since following an unstable channel
       # should give the required function with the right arguments (unless misunderstood).
       url =
-        "github:nix-community/home-manager/6a1922568337e7cf21175213d3aafd1ac79c9a2e";
-      inputs.nixpkgs.follows = "/nixpkgs-unstable";
+        # if using 22.11
+        #"github:nix-community/home-manager/6a1922568337e7cf21175213d3aafd1ac79c9a2e";
+        "github:nix-community/home-manager";
     };
     hardware = { url = "github:nixos/nixos-hardware/master"; };
 

--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -84,6 +84,10 @@
     "/dev/disk/by-uuid/c20f4b7d-5f67-4f24-b796-c6d1446ecd26";
 
   kernel-mod.ntfs3.enable = true;
+  console = {
+    font = "${pkgs.terminus_font}/share/consolefonts/ter-v32n.psf.gz";
+    earlySetup = true;
+  };
   audio.enable = true;
   devMachine.enable = true;
   nixpkgs = {
@@ -410,11 +414,20 @@
   environment.pathsToLink = [ "/share/zsh" ];
 
   fonts = {
-    fonts = with pkgs; [ noto-fonts noto-fonts-emoji nerdfonts powerline ];
+    fonts = with pkgs; [
+      noto-fonts
+      noto-fonts-emoji
+      (nerdfonts.overrideAttrs (prev: { enableWindowsFonts = true; }))
+      winePackages.fonts
+      vistafonts
+      powerline
+    ];
     enableDefaultFonts = true;
+    fontconfig = {
+      subpixel = { lcdfilter = "default"; };
+      defaultFonts.monospace = lib.mkForce [ "Source Code Pro for Powerline" ];
 
-    fontconfig.defaultFonts.monospace =
-      lib.mkForce [ "Source Code Pro for Powerline" ];
+    };
   };
   desktop = {
     common.enable = true;

--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -424,7 +424,7 @@
     podman = {
       enable = true;
       dockerCompat = true;
-      defaultNetwork.dnsname.enable = true;
+      defaultNetwork = { settings = { dns_enabled = true; }; };
     };
     libvirtd = { enable = true; };
     kvmgt = { enable = true; };

--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -374,7 +374,7 @@
     curl
     nerdfonts
     gcc_multi
-    openssl
+    #openssl
     niv
     # intel specific tools
     inteltool

--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -46,6 +46,7 @@
     systemd-boot = {
       enable = true;
       memtest86.enable = true;
+      consoleMode = "auto";
     };
     efi.canTouchEfiVariables = false;
   };

--- a/nixos/nyx/hardware-configuration.nix
+++ b/nixos/nyx/hardware-configuration.nix
@@ -48,5 +48,4 @@
   hardware.cpu.intel.updateMicrocode =
     lib.mkDefault config.hardware.enableRedistributableFirmware;
   # high-resolution display
-  hardware.video.hidpi.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
- META: moving to 23.05.
- META: 23.05: nyx: podman changed settings, fix.
- META: 23.05: kotatogram: remove.
- META: 23.05: kotatogram: extra info.
- META: 23.05: nyx: hardware-configuration: remove hidpi option.
- META: 23.05: nyx: configuration: set consoleMode.
- META: 23.05: nyx: configuration: set set font options.
- META: 23.05: nyx: configuration: remove explicit openssl install.
- FEAT: hm: kitty: bigger scrollback.
