### PR TITLE
FEAT/swayidle disable logind

### DIFF
--- a/features/hm/wayland/swayidle.nix
+++ b/features/hm/wayland/swayidle.nix
@@ -51,10 +51,10 @@ in {
       hyprctl = "${config.wayland.windowManager.hyprland.package}/bin/hyprctl";
     in {
       enable = true;
-      package = pkgs.unstable.swayidle;
       # NOTE: move towards letting logind handle most of the locking work
       # since there is a push to remove events and simply the codebase.
       # See: https://github.com/swaywm/swayidle/issues/117
+      package = nw.swayidle.override ({ systemdSupport = false; });
       timeouts = [
         {
           timeout = 300;

--- a/features/nixos/desktop/wayland/default.nix
+++ b/features/nixos/desktop/wayland/default.nix
@@ -12,8 +12,8 @@ in {
     };
   };
   imports = [
-  inputs.hyprland.nixosModules.default
-  "${inputs.slh}/nixos/modules/services/systemd-lock-handler"
+    inputs.hyprland.nixosModules.default
+    ../../../../overlays/modules/systemd-lock-handler
   ];
 
   config = let nw = inputs.nixpkgs-wayland.packages.${pkgs.system};

--- a/features/nixos/desktop/wayland/default.nix
+++ b/features/nixos/desktop/wayland/default.nix
@@ -80,6 +80,16 @@ in {
     ];
     services.systemd-lock-handler = {
       enable = true;
+      package = pkgs.systemd-lock-handler.overrideAttrs (old: rec {
+        version = "2.4.2";
+        src = pkgs.fetchFromSourcehut {
+          owner = "~whynothugo";
+          repo = "systemd-lock-handler";
+          rev = "v${version}";
+          hash = "sha256-sTVAabwWtyvHuDp/+8FKNbfej1x/egoa9z1jLIMJuBg=";
+        };
+        vendorHash = "";
+      });
     };
 
     programs.hyprland = {

--- a/features/nixos/desktop/wayland/default.nix
+++ b/features/nixos/desktop/wayland/default.nix
@@ -11,7 +11,11 @@ in {
       };
     };
   };
-  imports = [ inputs.hyprland.nixosModules.default ];
+  imports = [
+  inputs.hyprland.nixosModules.default
+  "${inputs.slh}/nixos/modules/services/systemd-lock-handler"
+  ];
+
   config = let nw = inputs.nixpkgs-wayland.packages.${pkgs.system};
   in lib.mkIf (cfg.wayland.laptop || cfg.wayland.desktop) {
     nix = {
@@ -74,6 +78,9 @@ in {
       })
 
     ];
+    services.systemd-lock-handler = {
+      enable = true;
+    };
 
     programs.hyprland = {
       enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
     nixneovimplugins.url = "github:jooooscha/nixpkgs-vim-extra-plugins";
     nixneovim.url = "github:nixneovim/nixneovim";
 
+    # this is for pr's that have not been merged yet.
+    slh.url = "github:MatthewCroughan/nixpkgs/mc/systemd-lock-handler";
   };
   outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, ... }@inputs:
     let
@@ -87,6 +89,7 @@
                 });
               electron-mail-latest =
                 (prev.callPackage ./pkgs/electron-mail { });
+              inherit (inputs.slh.legacyPackages.${prev.system}) systemd-lock-handler;
             })
           ];
         })

--- a/overlays/modules/systemd-lock-handler/default.nix
+++ b/overlays/modules/systemd-lock-handler/default.nix
@@ -1,0 +1,47 @@
+{ config, pkgs, lib, ... }:
+with lib;
+let cfg = config.services.systemd-lock-handler;
+in {
+  options.services.systemd-lock-handler = {
+    enable = mkEnableOption (lib.mdDoc "systemd-lock-handler");
+    package = mkOption {
+      default = pkgs.systemd-lock-handler;
+      defaultText = literalExpression "pkgs.systemd-lock-handler";
+      type = types.package;
+      description = lib.mdDoc "systemd-lock-handler package to use.";
+    };
+  };
+  config = mkIf cfg.enable {
+    systemd.user = {
+      targets = {
+        lock = {
+          conflicts = [ "unlock.target" ];
+          description = "Lock the currrent session";
+        };
+        unlock = {
+          conflicts = [ "lock.target" ];
+          description = "Unlock the currrent session";
+        };
+        sleep = {
+          description =
+            "User-level target triggered when the system is about to sleep";
+          requires = [ "lock.target" ];
+          after = [ "lock.target" ];
+        };
+      };
+      services.systemd-lock-handler = {
+        description = "Logind lock event to systemd target translation";
+        unitConfig.documentation =
+          "https://sr.ht/~whynothugo/systemd-lock-handler";
+        serviceConfig = {
+          Slice = [ "session.slice" ];
+          ExecStart = "${cfg.package}/bin/systemd-lock-handler";
+          Type = "notify";
+          Restart = "on-failure";
+          RestartSec = "10s";
+        };
+        wantedBy = [ "default.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hopefully this means a less buggy locking solution, in scenarios where monitors are removed.

- FEAT: systemd-lock-handler: alternative to swayidle's event functionality. Setup package and module on the nixos side.
- FEAT: systemd-lock-handler: remake module.
- FEAT: systemd-lock-handler: use latest version.
- FEAT: swayidle/swaylock: change to vanilla swaylock.
- FEAT: swayidle/swaylock: remove event entries.
- FEAT: swayidle: compile without systemd support.
