### PR TITLE
PKG: vim plugins: add stay-centered.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,8 @@
               vimPlugins = prev.vimPlugins // {
                 vimBeGood =
                   import ./pkgs/vimPlugins/vim-be-good { inherit pkgs; };
+                stay-centered =
+                  import ./pkgs/vimPlugins/stay-centered { inherit pkgs; };
               };
               powertop-git = prev.unstable.powertop.overrideAttrs (oldAttrs: {
                 version = "2.15-pre";

--- a/pkgs/vimPlugins/stay-centered/default.nix
+++ b/pkgs/vimPlugins/stay-centered/default.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+pkgs.vimUtils.buildVimPlugin rec {
+  name = "stay-centered";
+  src = pkgs.fetchFromGitHub {
+    owner = "arnamak";
+    repo = "${name}.nvim";
+    rev = "0715638e7110362f95ead35c290fcd040c2d2735";
+    sha256 = "iaaWmXtgTPr3zecWD94D5PVB1yanpEb+oH4R2ukTT+A=";
+  };
+}


### PR DESCRIPTION
Stay centered is a plugin that keeps the cursor in middle of the screen, thereby making it easier to find it, also helpful when searching.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>

