### PR TITLE
direnv: enable and configure.

### DIFF
--- a/features/hm/common/programs.nix
+++ b/features/hm/common/programs.nix
@@ -97,6 +97,10 @@
         };
 
       })) (lib.attrsets.optionalAttrs (config.devMachine.enable) {
+        direnv = {
+          enable = true;
+          nix-direnv.enable = true;
+        };
         gh = {
           enable = true;
           extensions = [ pkgs.gh-eco pkgs.gh-dash ];


### PR DESCRIPTION
* This brings the ability to enable development shells which bring make development easier *in the long run* as this configures per directory dependencies. So one project might need a specific version of python or php and this will make it seperate from other projects.

Signed-off-by: Michael Pacheco <git@michaelpacheco.org>
