### PR TITLE
FIX/vscode lldb test

### DIFF
--- a/overlays/vadimcn.vscode-lldb/adapter-output-shared_object.patch
+++ b/overlays/vadimcn.vscode-lldb/adapter-output-shared_object.patch
@@ -1,0 +1,22 @@
+From 4f64ad191ec79b9f40843f88e3ac5910720636da Mon Sep 17 00:00:00 2001
+From: Changsheng Wu <Congee@users.noreply.github.com>
+Date: Fri, 9 Jun 2023 15:41:53 -0400
+Subject: [PATCH] Update Cargo.toml
+
+---
+ adapter/Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/adapter/Cargo.toml b/adapter/Cargo.toml
+index bc86723..f5f26ce 100644
+--- a/adapter/Cargo.toml
++++ b/adapter/Cargo.toml
+@@ -39,7 +39,7 @@ winapi = { version = "0.3.8", features = ["std", "wincon", "namedpipeapi"] }
+ winreg = "0.6.2"
+
+ [lib]
+-crate-type = ["staticlib"]
++crate-type = ["dylib", "rlib"]
+
+ [[bin]]
+ name = "codelldb"

--- a/overlays/vadimcn.vscode-lldb/cmake-build-extension-only.patch
+++ b/overlays/vadimcn.vscode-lldb/cmake-build-extension-only.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,13 +16,6 @@
+ set(VERSION "${VERSION}${VERSION_SUFFIX}")
+ message("Version ${VERSION}")
+ 
+-set(LLDB_PACKAGE $ENV{LLDB_PACKAGE} CACHE PATH "Zip archive containing LLDB files")
+-if (LLDB_PACKAGE)
+-    message("Using LLDB_PACKAGE=${LLDB_PACKAGE}")
+-else()
+-    message(FATAL_ERROR "LLDB_PACKAGE not set." )
+-endif()
+-
+ if (CMAKE_SYSROOT)
+     set(CMAKE_C_FLAGS "--sysroot=${CMAKE_SYSROOT} ${CMAKE_C_FLAGS}")
+     set(CMAKE_CXX_FLAGS "--sysroot=${CMAKE_SYSROOT} ${CMAKE_CXX_FLAGS}")
+@@ -102,16 +95,6 @@
+ configure_file(webpack.config.js ${CMAKE_CURRENT_BINARY_DIR}/webpack.config.js @ONLY)
+ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ 
+-# Install node_modules
+-execute_process(
+-    COMMAND ${NPM} ci # like install, but actually respects package-lock file.
+-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+-    RESULT_VARIABLE Result
+-)
+-if (NOT ${Result} EQUAL 0)
+-    message(FATAL_ERROR "npm intall failed: ${Result}")
+-endif()
+-
+ # Resolve $refs
+ execute_process(
+     COMMAND ${WithEnv} NODE_PATH=${CMAKE_CURRENT_BINARY_DIR}/node_modules node ${CMAKE_CURRENT_SOURCE_DIR}/tools/prep-package.js ${CMAKE_CURRENT_BINARY_DIR}/package.json ${CMAKE_CURRENT_BINARY_DIR}/package.json
+@@ -169,6 +152,7 @@
+ 
+ add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_BINARY_DIR}/README.md)
+ add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md ${CMAKE_CURRENT_BINARY_DIR}/CHANGELOG.md)
++add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_CURRENT_BINARY_DIR}/LICENSE)
+ add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/lldb.png ${CMAKE_CURRENT_BINARY_DIR}/images/lldb.png)
+ add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/user.svg ${CMAKE_CURRENT_BINARY_DIR}/images/user.svg)
+ add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/users.svg ${CMAKE_CURRENT_BINARY_DIR}/images/users.svg)
+@@ -185,6 +169,7 @@
+ set(PackagedFilesBootstrap
+     README.md
+     CHANGELOG.md
++    LICENSE
+     extension.js
+     images/*
+     syntaxes/*

--- a/overlays/vadimcn.vscode-lldb/codelldb_debug.patch
+++ b/overlays/vadimcn.vscode-lldb/codelldb_debug.patch
@@ -1,0 +1,52 @@
+diff --git a/adapter/src/debug_session.rs b/adapter/src/debug_session.rs
+index d4cdef1..f772e93 100644
+--- a/adapter/src/debug_session.rs
++++ b/adapter/src/debug_session.rs
+@@ -112,14 +112,19 @@ impl DebugSession {
+         // Initialize Python
+         let (con_reader, con_writer) = pipe().unwrap();
+         let current_exe = env::current_exe().unwrap();
++        let d = debugger.command_interpreter();
++        let exe = current_exe.parent().unwrap();
++        let con = con_writer.try_clone().ok();
++        let a = d.is_valid();
++        error!(" DEBUG: Initialize Python interpreter:  debugger!: {a:?} EXE!: {exe:?} CON!: {con:?}" );
+         let (python, python_events) = match python::initialize(
+-            debugger.command_interpreter(),
+-            current_exe.parent().unwrap(),
+-            Some(con_writer.try_clone().unwrap()),
++            d,
++            exe,
++            con,
+         ) {
+             Ok((python, events)) => (Some(python), Some(events)),
+             Err(err) => {
+-                error!("Initialize Python interpreter: {}", err);
++                error!("Initialize Python interpreter: {err}" );
+                 (None, None)
+             }
+         };
+diff --git a/adapter/src/python.rs b/adapter/src/python.rs
+index 3d9e05c..71cb85f 100644
+--- a/adapter/src/python.rs
++++ b/adapter/src/python.rs
+@@ -93,6 +93,8 @@ pub fn initialize(
+     let init_script = adapter_dir.join("scripts/debugger.py");
+     let command = format!("command script import '{}'", init_script.to_str().unwrap());
+     interpreter.handle_command(&command, &mut command_result, false);
++    let out = command_result.output().to_str().unwrap();
++    error!("COMMAND: 97 CMD: {command} OUT: {out}");
+     if !command_result.succeeded() {
+         bail!(format!("{:?}", command_result));
+     }
+@@ -156,6 +158,10 @@ pub fn initialize(
+         py_log_level, init_callback as *const c_void, send_message_callback as *const c_void, interface
+     );
+     interface.interpreter.handle_command(&command, &mut command_result, false);
++    let out = command_result.output().to_str().unwrap();
++    let inter = interface.adapter_dir.to_str().unwrap();
++    error!("COMMAND: 162 CMD: {command} OUT: {out} ADAP_DIR {inter}");
++
+     if !command_result.succeeded() {
+         bail!(format!("{:?}", command_result));
+     }

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -1,0 +1,139 @@
+{ pkgs, lib, stdenv, fetchFromGitHub, runCommand, rustPlatform, makeWrapper, llvmPackages
+, buildNpmPackage, cmake, nodejs, unzip, python3, pkg-config, libsecret, darwin
+}:
+assert lib.versionAtLeast python3.version "3.5";
+let
+  publisher = "vadimcn";
+  pname = "vscode-lldb";
+  version = "1.9.2";
+
+  vscodeExtUniqueId = "${publisher}.${pname}";
+  vscodeExtPublisher = publisher;
+  vscodeExtName = pname;
+
+  src = fetchFromGitHub {
+    owner = "vadimcn";
+    repo = "vscode-lldb";
+    rev = "v${version}";
+    hash = "sha256-6QmYRlSv8jY3OE3RcYuZt+c3z6GhFc8ESETVfCfF5RI=";
+  };
+
+  # need to build a custom version of lldb and llvm for enhanced rust support
+  lldb = (import ./lldb.nix { inherit fetchFromGitHub runCommand llvmPackages; });
+
+  adapter = rustPlatform.buildRustPackage {
+    pname = "${pname}-adapter";
+    inherit version src;
+
+    cargoHash = "sha256-Qq2igtH1XIB+NAEES6hdNZcMbEmaFN69qIJ+gTYupvQ=";
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    buildAndTestSubdir = "adapter";
+
+    buildFeatures = [ "weak-linkage" ];
+
+    cargoBuildFlags = [
+      "--lib"
+      "--bin=codelldb"
+    ];
+
+    patches = [ ./adapter-output-shared_object.patch ];
+
+    # Tests are linked to liblldb but it is not available here.
+    doCheck = false;
+  };
+
+  nodeDeps = buildNpmPackage {
+    pname = "${pname}-node-deps";
+    inherit version src;
+
+    npmDepsHash = "sha256-fMKGi+AJTMlWl7SQtZ21hUwOLgqlFYDhwLvEergQLfI=";
+
+    nativeBuildInputs = [
+      python3
+      pkg-config
+    ];
+
+    buildInputs = [
+      libsecret
+    ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      Security
+      AppKit
+    ]);
+
+    dontNpmBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib
+      cp -r node_modules $out/lib
+
+      runHook postInstall
+    '';
+  };
+
+in stdenv.mkDerivation {
+  pname = "vscode-extension-${publisher}-${pname}";
+  inherit src version vscodeExtUniqueId vscodeExtPublisher vscodeExtName;
+
+  installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
+
+  nativeBuildInputs = [ cmake nodejs unzip makeWrapper ];
+
+  patches = [ ./cmake-build-extension-only.patch ];
+
+  postConfigure = ''
+    cp -r ${nodeDeps}/lib/node_modules .
+  '';
+
+  cmakeFlags = [
+    # Do not append timestamp to version.
+    "-DVERSION_SUFFIX="
+  ];
+  makeFlags = [ "vsix_bootstrap" ];
+
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase = ''
+    ext=$out/$installPrefix
+    runHook preInstall
+
+    unzip ./codelldb-bootstrap.vsix 'extension/*' -d ./vsix-extracted
+
+    mkdir -p $ext/{adapter,formatters}
+    mv -t $ext vsix-extracted/extension/*
+    cp -t $ext/adapter ${adapter}/{bin,lib}/* ../adapter/*.py
+    wrapProgram $ext/adapter/codelldb \
+      --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
+    cp -t $ext/formatters ../formatters/*.py
+    ln -s ${lldb.lib} $ext/lldb
+    # Mark that all components are installed.
+    touch $ext/platform.ok
+
+    runHook postInstall
+  '';
+
+  # `adapter` will find python binary and libraries at runtime.
+  postFixup = ''
+    wrapProgram $out/$installPrefix/adapter/codelldb \
+      --prefix PATH : "${python3}/bin" \
+      --prefix LD_LIBRARY_PATH : "${python3}/lib"
+  '';
+
+  passthru = {
+    inherit lldb adapter;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "A native debugger extension for VSCode based on LLDB";
+    homepage = "https://github.com/vadimcn/vscode-lldb";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.nigelgbanks ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -110,11 +110,12 @@ in stdenv.mkDerivation {
     wrapProgram $ext/adapter/codelldb \
       --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
     cp -t $ext/formatters ../formatters/*.py
-    #ln -s ${lldb.lib} $ext/lldb
-    mkdir  $ext/lldb
-    for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb/; done
-    unlink $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+    # ln -s ${lldb.lib} $ext/lldb
+    mkdir  $ext/lldb/
+for file in ${lldb.lib}/*; do if [[ ! "$file" =~ lldb-argdumper ]]; then ln -s "$file" "$ext/lldb/$file"; fi; done
     ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+    # for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb/; done
+    # unlink $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
     # Mark that all components are installed.
     touch $ext/platform.ok
 

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -73,67 +73,12 @@ let
       runHook postInstall
     '';
   };
+in
+  stdenv.mkDerivation {
+    pname = "vscode-extension-${publisher}-${pname}";
+    inherit src version vscodeExtUniqueId vscodeExtPublisher vscodeExtName;
 
-in stdenv.mkDerivation {
-  pname = "vscode-extension-${publisher}-${pname}";
-  inherit src version vscodeExtUniqueId vscodeExtPublisher vscodeExtName;
-
-  installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
-
-  nativeBuildInputs = [ cmake nodejs unzip makeWrapper ];
-
-  patches = [ ./cmake-build-extension-only.patch ];
-
-  postConfigure = ''
-    cp -r ${nodeDeps}/lib/node_modules .
-  '';
-
-  cmakeFlags = [
-    # Do not append timestamp to version.
-    "-DVERSION_SUFFIX="
-  ];
-  makeFlags = [ "vsix_bootstrap" ];
-
-  preBuild = lib.optionalString stdenv.isDarwin ''
-    export HOME=$TMPDIR
-  '';
-
-  installPhase = ''
-    ext=$out/$installPrefix
-    runHook preInstall
-
-    unzip ./codelldb-bootstrap.vsix 'extension/*' -d ./vsix-extracted
-
-    mkdir -p $ext/{adapter,formatters}
-    mv -t $ext vsix-extracted/extension/*
-    cp -t $ext/adapter ${adapter}/{bin,lib}/* ../adapter/*.py
-    wrapProgram $ext/adapter/codelldb \
-      --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
-    cp -t $ext/formatters ../formatters/*.py
-    ln -s ${lldb.lib} $ext/lldb
-    # mkdir  $ext/lldb/
-    # for file in ${lldb.lib}/*; do if [[ ! "$file" =~ lldb-argdumper ]]; then ln -s "$file" "$ext/lldb/"; fi; done
-    #for file in ${lldb.lib}/*; do ln -s "${lldb.lib}/$link" $ext/lldb/; done
-    # ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
-    # for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb/; done
-    # whoami
-    # Mark that all components are installed.
-    touch $ext/platform.ok
-
-    runHook postInstall
-  '';
-
-  # `adapter` will find python binary and libraries at runtime.
-  postFixup = ''
-    wrapProgram $out/$installPrefix/adapter/codelldb \
-      --prefix PATH : "${python3}/bin" \
-      --prefix LD_LIBRARY_PATH : "${python3}/lib"
-  '';
-
-  passthru = {
-    inherit lldb adapter;
-    updateScript = ./update.sh;
-  };
+    installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
 
     nativeBuildInputs = [cmake nodejs unzip makeWrapper];
     patches = [./cmake-build-extension-only.patch];
@@ -160,32 +105,17 @@ in stdenv.mkDerivation {
 
       mkdir -p $ext/{adapter,formatters}
       mv -t $ext vsix-extracted/extension/*
-      cp -t $ext/adapter ${adapter}/{bin,lib}/* ../adapter/*.py
+      cp -t $ext/adapter ${adapter}/{bin,lib}/*
+      cp -r $src/adapter/scripts $out/adapter/
       wrapProgram $ext/adapter/codelldb \
         --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
       cp -t $ext/formatters ../formatters/*.py
       ln -s ${lldb.lib} $ext/lldb
-      # mkdir  $ext/lldb/
-      # for file in ${lldb.lib}/*; do if [[ ! "$file" =~ lldb-argdumper ]]; then ln -s "$file" "$ext/lldb/"; fi; done
-      #for file in ${lldb.lib}/*; do ln -s "${lldb.lib}/$link" $ext/lldb/; done
-      # ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
-      # for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb/; done
-      # whoami
-      # Mark that all components are installed.
       touch $ext/platform.ok
 
       runHook postInstall
     '';
 
-    postInstall = ''
-      ls -lah $src/adapter/scripts
-
-      cp -r $src/adapter/scripts $out/adapter/
-      ls -lah $out/
-      ls -lah $out/bin
-      ls -lah $out/lib
-
-    '';
     # `adapter` will find python binary and libraries at runtime.
     postFixup = ''
       wrapProgram $out/$installPrefix/adapter/codelldb \

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -19,7 +19,7 @@ let
   };
 
   # need to build a custom version of lldb and llvm for enhanced rust support
-  lldb = (import ./lldb.nix { inherit fetchFromGitHub runCommand llvmPackages; });
+  lldb = (import ./lldb.nix { inherit fetchFromGitHub runCommand llvmPackages python3; });
 
   adapter = rustPlatform.buildRustPackage {
     pname = "${pname}-adapter";
@@ -38,7 +38,7 @@ let
       "--bin=codelldb"
     ];
 
-    patches = [ ./adapter-output-shared_object.patch ];
+    patches = [ ./adapter-output-shared_object.patch ./codelldb_debug.patch ];
 
     # Tests are linked to liblldb but it is not available here.
     doCheck = false;
@@ -110,12 +110,13 @@ in stdenv.mkDerivation {
     wrapProgram $ext/adapter/codelldb \
       --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
     cp -t $ext/formatters ../formatters/*.py
-    # ln -s ${lldb.lib} $ext/lldb
-    mkdir  $ext/lldb/
-for file in ${lldb.lib}/*; do if [[ ! "$file" =~ lldb-argdumper ]]; then ln -s "$file" "$ext/lldb/$file"; fi; done
-    ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+    ln -s ${lldb.lib} $ext/lldb
+    # mkdir  $ext/lldb/
+    # for file in ${lldb.lib}/*; do if [[ ! "$file" =~ lldb-argdumper ]]; then ln -s "$file" "$ext/lldb/"; fi; done
+    #for file in ${lldb.lib}/*; do ln -s "${lldb.lib}/$link" $ext/lldb/; done
+    # ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
     # for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb/; done
-    # unlink $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+    # whoami
     # Mark that all components are installed.
     touch $ext/platform.ok
 

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -111,6 +111,9 @@ in stdenv.mkDerivation {
       --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
     cp -t $ext/formatters ../formatters/*.py
     ln -s ${lldb.lib} $ext/lldb
+    rm $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+    ln -s ${lldb.bin}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+
     # Mark that all components are installed.
     touch $ext/platform.ok
 

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -110,10 +110,11 @@ in stdenv.mkDerivation {
     wrapProgram $ext/adapter/codelldb \
       --set-default LLDB_DEBUGSERVER_PATH "${lldb.out}/bin/lldb-server"
     cp -t $ext/formatters ../formatters/*.py
-    ln -s ${lldb.lib} $ext/lldb
+    #ln -s ${lldb.lib} $ext/lldb
+    mkdir  $ext/lldb
+    for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb
     rm $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
-    ln -s ${lldb.bin}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
-
+    ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
     # Mark that all components are installed.
     touch $ext/platform.ok
 

--- a/overlays/vadimcn.vscode-lldb/default.nix
+++ b/overlays/vadimcn.vscode-lldb/default.nix
@@ -112,8 +112,8 @@ in stdenv.mkDerivation {
     cp -t $ext/formatters ../formatters/*.py
     #ln -s ${lldb.lib} $ext/lldb
     mkdir  $ext/lldb
-    for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb
-    rm $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
+    for link in ${lldb.lib}/*; do ln -s "$link" $ext/lldb/; done
+    unlink $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
     ln -s ${lldb.out}/bin/lldb-argdumper $ext/lldb/lib/python3.10/site-packages/lldb/lldb-argdumper
     # Mark that all components are installed.
     touch $ext/platform.ok

--- a/overlays/vadimcn.vscode-lldb/fix-python-installation.patch
+++ b/overlays/vadimcn.vscode-lldb/fix-python-installation.patch
@@ -1,0 +1,13 @@
+diff --git a/bindings/python/CMakeLists.txt b/bindings/python/CMakeLists.txt
+index 82a52da89a7e..5127dc1d8f41 100644
+--- a/bindings/python/CMakeLists.txt
++++ b/bindings/python/CMakeLists.txt
+@@ -160,7 +160,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
+   if(LLDB_BUILD_FRAMEWORK)
+     set(LLDB_PYTHON_INSTALL_PATH ${LLDB_FRAMEWORK_INSTALL_DIR}/LLDB.framework/Versions/${LLDB_FRAMEWORK_VERSION}/Resources/Python)
+   else()
+-    set(LLDB_PYTHON_INSTALL_PATH ${LLDB_PYTHON_RELATIVE_PATH})
++    set(LLDB_PYTHON_INSTALL_PATH ${CMAKE_INSTALL_LIBDIR}/../${LLDB_PYTHON_RELATIVE_PATH})
+   endif()
+   if (NOT CMAKE_CFG_INTDIR STREQUAL  ".")
+     string(REPLACE ${CMAKE_CFG_INTDIR} "\$\{CMAKE_INSTALL_CONFIG_NAME\}" LLDB_PYTHON_INSTALL_PATH ${LLDB_PYTHON_INSTALL_PATH})

--- a/overlays/vadimcn.vscode-lldb/lldb.nix
+++ b/overlays/vadimcn.vscode-lldb/lldb.nix
@@ -1,0 +1,42 @@
+# Patched lldb for Rust language support.
+{ fetchFromGitHub, runCommand, llvmPackages, python3 }:
+let
+  llvmSrc = fetchFromGitHub {
+    owner = "vadimcn";
+    repo = "llvm-project";
+    # codelldb/14.x branch
+    rev = "4c267c83cbb55fedf2e0b89644dc1db320fdfde7";
+    sha256 = "sha256-jM//ej6AxnRYj+8BAn4QrxHPT6HiDzK5RqHPSg3dCcw=";
+  };
+in (llvmPackages.lldb.overrideAttrs (oldAttrs: rec {
+  version = "${oldAttrs.version}-patched";
+  passthru = (oldAttrs.passthru or {}) // {
+    inherit llvmSrc;
+  };
+
+  patches = oldAttrs.patches ++ [
+    # backport of https://github.com/NixOS/nixpkgs/commit/0d3002334850a819d1a5c8283c39f114af907cd4
+    # remove when https://github.com/NixOS/nixpkgs/issues/166604 fixed
+    ./fix-python-installation.patch
+  ];
+
+  doInstallCheck = true;
+  # Extremely hacky way to deal with the bad symlink on the file
+  postInstall = ''
+  rm $lib/${python3.sitePackages}/lldb/lldb-argdumper
+  # get a cyclic symlink error, instead just do a copy
+  cp $out/bin/lldb-argdumper $lib/${python3.sitePackages}/lldb/
+  '';
+
+  # installCheck for lldb_14 currently broken
+  # https://github.com/NixOS/nixpkgs/issues/166604#issuecomment-1086103692
+  # ignore the oldAttrs installCheck
+  installCheckPhase = ''
+    versionOutput="$($out/bin/lldb --version)"
+    echo "'lldb --version' returns: $versionOutput"
+    echo "$versionOutput" | grep -q 'rust-enabled'
+  '';
+})).override({
+  monorepoSrc = llvmSrc;
+  libllvm = llvmPackages.libllvm.override({ monorepoSrc = llvmSrc; });
+})

--- a/overlays/vadimcn.vscode-lldb/update.sh
+++ b/overlays/vadimcn.vscode-lldb/update.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env nix-shell
+#! nix-shell ../../update-shell.nix -i bash -p nix-prefetch-github prefetch-npm-deps
+
+set -eo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+echo "
+FIXME: This script doesn't update patched lldb. Please manually check branches
+of https://github.com/vadimcn/llvm-project and update lldb with correct version of LLVM.
+"
+
+# Ideally, nixpkgs points to default.nix file of Nixpkgs official tree
+nixpkgs=../../../../../..
+nixFile=./default.nix
+owner=vadimcn
+repo=vscode-lldb
+version="$1"
+if [[ $# -ne 1 ]]; then
+    # no version specified, find the newest one
+    version=$(
+        curl -sL "https://api.github.com/repos/$owner/$repo/releases" |
+        jq 'map(select(.prerelease | not)) | .[0].tag_name' --raw-output |
+        sed 's/[\"v]//'
+    )
+fi
+old_version=$(sed -nE 's/.*\bversion = "(.*)".*/\1/p' ./default.nix)
+if grep -q 'cargoSha256 = ""' ./default.nix; then
+    old_version='broken'
+fi
+if [[ "$version" == "$old_version" ]]; then
+    echo "Up to date: $version"
+fi
+echo "$old_version -> $version"
+
+# update hashes
+sed -E 's/\bversion = ".*?"/version = "'$version'"/' --in-place "$nixFile"
+srcHash=$(nix-prefetch-github vadimcn vscode-lldb --rev "v$version" | jq --raw-output .sha256)
+sed -E 's#\bsha256 = ".*?"#sha256 = "'$srcHash'"#' --in-place "$nixFile"
+cargoHash=$(nix-prefetch "{ sha256 }: (import $nixpkgs {}).vscode-extensions.vadimcn.vscode-lldb.adapter.cargoDeps.overrideAttrs (_: { outputHash = sha256; })")
+sed -E 's#\bcargoSha256 = ".*?"#cargoSha256 = "'$cargoHash'"#' --in-place "$nixFile"
+
+pushd $TMPDIR
+curl -LO https://raw.githubusercontent.com/$owner/$repo/v${version}/package-lock.json
+npmDepsHash=$(prefetch-npm-deps ./package-lock.json)
+popd
+sed -E 's#\bnpmDepsHash = ".*?"#npmDepsHash = "'$npmDepsHash'"#' --in-place "$nixFile"
+


### PR DESCRIPTION
- vscode-lldb: import as local package.
- vscode-lldb: fix lldb-argdumper symlink.
- vscode-lldb: manually link all the files.
- vscode-lldb: manually link all items. part duex.
- vscode-lldb: manually link all items. part trois.
- vscode-lldb: add patches.
- vscode-lldb: Actual fix: scripts were moved, fix.
- vscode-lldb: Actual fix: cleanup.
