### PR TITLE
FEAT: gpg: rework certain portions.

### DIFF
--- a/features/hm/gpg/default.nix
+++ b/features/hm/gpg/default.nix
@@ -1,24 +1,32 @@
-{ config, pkgs, lib, ... }:
-let
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
   cfgWM = config.wayland.windowManager;
   # generate a list of wayalnd window managers containing only enablement condition.
   # This assumes that only a attrset of window managers will be here.
   waylandWMList = lib.attrsets.mapAttrsToList (n: v: v.enable) cfgWM;
   # If there are any wm's enabled this will be true.
-  waylandEnabled = lib.lists.findFirst (wm: wm == true) false waylandWMList;
+  # NOTE: findFirst accepts a function that returns a boolean, since this is just a list of booleans, a simple function
+  # returning the value is enough
+  waylandEnabled = lib.lists.findFirst (wm: wm) false waylandWMList;
 
   pinentryFlavor =
-    if (config.xsession.enable || waylandEnabled) then "gtk2" else "curses";
+    if (config.xsession.enable || waylandEnabled)
+    then "gtk2"
+    else "curses";
 in {
-  # TODO: Need to find how nix does a if "package is installed", need to find out why.
+  # TODO: (med prio) (research needed) Need to find how nix does a if "package is installed", need to find out why.
   programs.zsh.oh-my-zsh.plugins = lib.optionals (config.programs.gpg.enable
-    && config.programs.zsh.enable && config.programs.zsh.oh-my-zsh.enable)
-    [ "gpg-agent" ];
-  home.file.".gnupg/gpg.conf".text = import ./gpg.conf.nix { };
+    && config.programs.zsh.enable
+    && config.programs.zsh.oh-my-zsh.enable)
+  ["gpg-agent"];
+  home.file.".gnupg/gpg.conf".text = import ./gpg.conf.nix {};
   home.file.".gnupg/gpg-agent.conf".text = import ./gpg-agent.conf.nix {
     inherit pkgs;
     inherit pinentryFlavor;
   };
-  home.file.".gnupg/scdaemon.conf".text = import ./scdaemon.conf.nix { };
-
+  home.file.".gnupg/scdaemon.conf".text = import ./scdaemon.conf.nix {};
 }

--- a/features/hm/gpg/gpg-agent.conf.nix
+++ b/features/hm/gpg/gpg-agent.conf.nix
@@ -1,11 +1,14 @@
-{ pkgs, pinentryFlavor }:
-
-''
-  # https://github.com/drduh/config/blob/master/gpg-agent.conf
-  # https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html
+{
+  pkgs,
+  pinentryFlavor,
+}: ''
   enable-ssh-support
   ttyname $GPG_TTY
   default-cache-ttl 60
   max-cache-ttl 120
   pinentry-program ${pkgs.pinentry.${pinentryFlavor}}/bin/pinentry
 ''
+# https://github.com/drduh/config/blob/master/gpg-agent.conf
+# https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html
+# testing out shared-access, so that gpg and opensc work
+# TODO: need to override this with a shared-access

--- a/features/hm/gpg/gpg.conf.nix
+++ b/features/hm/gpg/gpg.conf.nix
@@ -1,6 +1,4 @@
-{ }:
-
-''
+_: ''
   # https://github.com/drduh/config/blob/master/gpg.conf
   # https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration-Options.html
   # https://www.gnupg.org/documentation/manuals/gnupg/GPG-Esoteric-Options.html

--- a/features/hm/gpg/scdaemon.conf.nix
+++ b/features/hm/gpg/scdaemon.conf.nix
@@ -1,6 +1,7 @@
-{ }:
-
-''
-  reader-port Yubico Yubikey
+_: ''
+  verbose
   disable-ccid
+  pcsc-shared
 ''
+# shared-access
+# reader-port Yubico Yubi


### PR DESCRIPTION
* This is supposed to fix certain errors with pcsd-lite wanting access even though scdeamon is holding exclusive access to the smartcard.
* WARN: the downside is that now, password caching does not happen (part of holding exclusive access) which means for every gpg action, password needs to be inputed.
* TODO: Find a way either to completely disable pcsd-lite and only use scdeamon, stop pcsd when gpg operations happen and after lockout start it again (dubious), or handle password caching somewhere else (might be a bad idea).
