### PR TITLE
chore: formatting on ssh.nix

### DIFF
--- a/features/hm/ssh/default.nix
+++ b/features/hm/ssh/default.nix
@@ -1,27 +1,31 @@
-{ ... }:
-let
-  identityFile = [ "~/.ssh/id_ed25519_sk_828" "~/.ssh/id_ed25519_sk_718" ];
-  mkHost = { hostname, user ? "sysadm", port ? 22
-    , extraOptions ? { PreferredAuthentications = "publickey"; } }: {
-      inherit hostname identityFile user port extraOptions;
-      identitiesOnly = true;
-    };
-
+_: let
+  identityFile = ["~/.ssh/id_ed25519_sk_828" "~/.ssh/id_ed25519_sk_718"];
+  mkHost = {
+    hostname,
+    user ? "sysadm",
+    port ? 22,
+    extraOptions ? {PreferredAuthentications = "publickey";},
+  }: {
+    inherit hostname identityFile user port extraOptions;
+    identitiesOnly = true;
+  };
 in {
-  imports = [ ];
-  options = { };
+  imports = [];
+  options = {};
   config = {
     programs = {
       ssh = {
         enable = true;
         compression = true;
         matchBlocks = {
-          "github.com" = mkHost {
-            hostname = "github.com";
-            user = "git";
-          } // {
-            #extraOptions = { MACs = "hmac-sha2-512"; };
-          };
+          "github.com" =
+            mkHost {
+              hostname = "github.com";
+              user = "git";
+            }
+            // {
+              #extraOptions = { MACs = "hmac-sha2-512"; };
+            };
           # Mac-Pro
           # will look into setting either Match or proxy command
           # https://unix.stackexchange.com/a/175395 < match
@@ -31,7 +35,7 @@ in {
             hostname = "172.30.0.2";
             user = "michael";
           };
-          # Cloud node referred as gaia on rhel 
+          # Cloud node referred as gaia on rhel
           "khaos" = mkHost {
             hostname = "172.30.0.20";
             user = "sysadm";
@@ -53,7 +57,7 @@ in {
           };
           # local ryzen server prev known as zeus
           # local ip is 192.168.1.5
-          "kore" = mkHost { hostname = "172.30.0.5"; };
+          "kore" = mkHost {hostname = "172.30.0.5";};
           "decrypt@kore" = mkHost {
             hostname = "192.168.1.5";
             user = "root";
@@ -64,9 +68,9 @@ in {
             user = "deploy";
           };
           # aarch64 master node prev known as atlas
-          "hades" = mkHost { hostname = "172.30.0.4"; };
+          "hades" = mkHost {hostname = "172.30.0.4";};
           # vm: local ip is 192.168.1.8
-          "odin" = mkHost { hostname = "172.30.0.11"; };
+          "odin" = mkHost {hostname = "172.30.0.11";};
         };
       };
     };


### PR DESCRIPTION
* This includes moving to the more idiomatic _: style of defining an empty parameter list. This is not  formatting done by default by alejandra but offered by the linter.

* TODO: make a GH action that check formatting and then do not allow the pr to be merged if it fails.
