### PR TITLE
feat/submap mode overlay

### DIFF
--- a/features/hm/wayland/quickshell/task-bar/desktop/ModeOverlay.qml
+++ b/features/hm/wayland/quickshell/task-bar/desktop/ModeOverlay.qml
@@ -63,8 +63,11 @@ PanelWindow {
         ringColor: root.theme.accent
         pulseColor: root.theme.accent
         pulseGapMs: 1200
-        // Complement of ModePill's gate: this surface only exists while the bar
-        // is covered, so only one of the two ever animates.
+        // Complement of ModePill's gate: this surface only exists while THIS
+        // monitor's bar is covered, so on a single monitor only one of the two
+        // ever animates. Across monitors that is not true: a fullscreen window
+        // on one monitor pulses its overlay while another monitor's bar pill
+        // pulses too.
         pulseActive: root.visible
 
         Lib.ModeBadge {

--- a/features/hm/wayland/quickshell/task-bar/desktop/ModeOverlay.qml
+++ b/features/hm/wayland/quickshell/task-bar/desktop/ModeOverlay.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import "../lib" as Lib
+
+// Fullscreen-proof submap indicator. The bar is a WlrLayer.Top surface, so a
+// fullscreen window covers it and Taskbar.surfaceVisible gates it off, taking
+// the only signal that a submap is active away with it. That is not cosmetic:
+// a submap without a catchall bind does not swallow typing, so a stuck one
+// presents as "the keyboard is wedged" with nothing on screen naming the cause.
+// This is the same badge on the Overlay layer, which Hyprland paints above
+// fullscreen windows.
+//
+// Deliberately NOT desktop/ModePill.qml. That carries a ModePopup plus a
+// HoverBridge for hover key hints, and the empty input region below means this
+// surface receives no pointer events at all, so the popup could never open.
+PanelWindow {
+    id: root
+
+    required property QtObject theme
+    // NB: this must NOT be named submapSvc. Across the Variants delegate in
+    // shell.qml an object's own property shadows an enclosing id, so
+    // `submapSvc: submapSvc` would resolve to this component's own null
+    // property. Same trap as netSvc, routerSvc and powerzStats.
+    required property var svc
+    // True while a fullscreen window covers THIS monitor's bar.
+    required property bool covered
+    // True while the session lock owns the screen.
+    required property bool locked
+    // Bound to the bar's own height rather than restating it, so the two cannot
+    // drift apart.
+    required property int barHeight
+
+    visible: root.svc && root.svc.current !== "" && root.covered && !root.locked
+
+    // Full width like Taskbar, with the pill centred inside, rather than
+    // anchoring only the top edge and letting layer-shell centre the surface.
+    // The single-edge form is what the protocol specifies, but no PanelWindow in
+    // this tree anchors fewer than two edges, and the empty input region below
+    // makes the extra width free of input cost. This also puts the pill on the
+    // same axis as the bar's own centerRow.
+    anchors {
+        top: true
+        left: true
+        right: true
+    }
+    implicitHeight: root.barHeight
+    color: "transparent"
+
+    exclusionMode: ExclusionMode.Ignore
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.namespace: "quickshell:mode"
+    // Click-through. Without an empty input region this eats every click in the
+    // top centre of a fullscreen game.
+    mask: Region {}
+    // Never take keys, least of all while a submap is active.
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+
+    Lib.Pill {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        theme: root.theme
+        ringColor: root.theme.accent
+        pulseColor: root.theme.accent
+        pulseGapMs: 1200
+        // Complement of ModePill's gate: this surface only exists while the bar
+        // is covered, so only one of the two ever animates.
+        pulseActive: root.visible
+
+        Lib.ModeBadge {
+            theme: root.theme
+            svc: root.svc
+        }
+    }
+}

--- a/features/hm/wayland/quickshell/task-bar/desktop/ModePill.qml
+++ b/features/hm/wayland/quickshell/task-bar/desktop/ModePill.qml
@@ -29,9 +29,13 @@ Item {
         // Pulse only while this bar is actually on screen. An animation left
         // running in a hidden layer surface still paints at the monitor refresh
         // rate (112 fps measured on a hidden 120 Hz bar), and desktop/
-        // ModeOverlay.qml carries the signal while the bar is covered. The two
-        // conditions are complements, so exactly one of them ever animates.
-        pulseActive: root.barWindow ? root.barWindow.surfaceVisible : false
+        // ModeOverlay.qml carries the signal while the bar is covered. On a
+        // single monitor the two conditions are complements, so exactly one of
+        // them ever animates. The root.visible term is what actually stops the
+        // timer when no submap is active: Lib.Pill's own pulse Timer is not
+        // gated by its parent Item's visibility, so without it the timer would
+        // free-run every 33ms forever, on every monitor, even at idle.
+        pulseActive: root.visible && (root.barWindow ? root.barWindow.surfaceVisible : false)
 
         Lib.ModeBadge {
             theme: root.theme

--- a/features/hm/wayland/quickshell/task-bar/desktop/ModePill.qml
+++ b/features/hm/wayland/quickshell/task-bar/desktop/ModePill.qml
@@ -4,7 +4,7 @@ import "../lib" as Lib
 
 // Bar-center mode indicator: the active Hyprland submap's icon + label, hidden in
 // the default map. Hover opens a key-hints popup (hover-persist + hide-bridge, per
-// the bar idiom). Sits in centerRow and rides the layout; svc may be null-guarded.
+// the bar idiom). Sits in rightRow and rides the layout; svc may be null-guarded.
 // Uses Lib.Pill so it shares the other clusters' floating layer (glass fill, drop
 // shadow, width spring, BarStyle) -- distinguished by an accent ring + accent text.
 Item {
@@ -22,24 +22,10 @@ Item {
         anchors.centerIn: parent
         theme: root.theme
         ringColor: root.theme.accent
-        gap: 6
 
-        Lib.BarText {
-            Layout.alignment: Qt.AlignVCenter
-            visible: root.svc && root.svc.iconCp() !== ""
-            text: (root.svc && root.svc.iconCp() !== "")
-                ? String.fromCharCode(parseInt(root.svc.iconCp(), 16)) : ""
-            font.family: root.theme.faFont
-            font.pixelSize: 12
-            color: root.theme.accent
-        }
-        Lib.BarText {
-            Layout.alignment: Qt.AlignVCenter
-            text: root.svc ? root.svc.label() : ""
-            font.family: root.theme.iconFont
-            font.pixelSize: 11
-            font.weight: Font.DemiBold
-            color: root.theme.accent
+        Lib.ModeBadge {
+            theme: root.theme
+            svc: root.svc
         }
     }
 

--- a/features/hm/wayland/quickshell/task-bar/desktop/ModePill.qml
+++ b/features/hm/wayland/quickshell/task-bar/desktop/ModePill.qml
@@ -22,6 +22,16 @@ Item {
         anchors.centerIn: parent
         theme: root.theme
         ringColor: root.theme.accent
+        pulseColor: root.theme.accent
+        // 4300 is Pill's default, tuned for an ambient weather alert. A "you are
+        // in a mode" signal wants a faster cadence.
+        pulseGapMs: 1200
+        // Pulse only while this bar is actually on screen. An animation left
+        // running in a hidden layer surface still paints at the monitor refresh
+        // rate (112 fps measured on a hidden 120 Hz bar), and desktop/
+        // ModeOverlay.qml carries the signal while the bar is covered. The two
+        // conditions are complements, so exactly one of them ever animates.
+        pulseActive: root.barWindow ? root.barWindow.surfaceVisible : false
 
         Lib.ModeBadge {
             theme: root.theme

--- a/features/hm/wayland/quickshell/task-bar/desktop/Taskbar.qml
+++ b/features/hm/wayland/quickshell/task-bar/desktop/Taskbar.qml
@@ -80,10 +80,17 @@ PanelWindow {
     // already relied on below (the tab strip reads .class from it). Measured
     // end to end: gate engages ~0.6s after a fullscreen window maps and
     // releases ~0.6s after it goes away.
+    //
+    // Hyprland's fullscreen field is a mode enum, not a bool: 0 = none, 1 =
+    // maximized, 2 = fullscreen. A maximized window does not cover a Top-layer
+    // bar, so the test below checks === 2, not > 0 -- desktop/ModeOverlay.qml
+    // uses this property's complement as a visibility predicate, and treating
+    // maximize as "covered" would show the overlay badge while the bar and its
+    // own pill were still on screen underneath it.
     readonly property bool surfaceVisible: {
         var list = Hyprland.toplevels?.values ?? [];
         for (var i = 0; i < list.length; i++)
-            if ((list[i].workspace?.id ?? -2) === dock.activeWs && (list[i].lastIpcObject?.fullscreen ?? 0) > 0)
+            if ((list[i].workspace?.id ?? -2) === dock.activeWs && (list[i].lastIpcObject?.fullscreen ?? 0) === 2)
                 return false;
         return true;
     }

--- a/features/hm/wayland/quickshell/task-bar/lib/ModeBadge.qml
+++ b/features/hm/wayland/quickshell/task-bar/lib/ModeBadge.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import QtQuick.Layouts
+import "modefmt.js" as ModeFmt
+
+// The submap icon glyph plus its label. Shared by the bar pill
+// (desktop/ModePill.qml) and the fullscreen overlay (desktop/ModeOverlay.qml)
+// so the glyph, fonts, sizes and accent colour cannot drift between the two.
+//
+// Owns no layout policy beyond its own spacing: each consumer drops it into its
+// own Lib.Pill as a single content item, which is why the consumers no longer
+// set Pill.gap.
+RowLayout {
+    id: badge
+
+    required property QtObject theme
+    required property var svc
+
+    spacing: 6
+
+    readonly property string glyph: badge.svc ? ModeFmt.glyphFor(badge.svc.iconCp()) : ""
+
+    BarText {
+        Layout.alignment: Qt.AlignVCenter
+        visible: badge.glyph !== ""
+        text: badge.glyph
+        font.family: badge.theme.faFont
+        font.pixelSize: 12
+        color: badge.theme.accent
+    }
+    BarText {
+        Layout.alignment: Qt.AlignVCenter
+        text: badge.svc ? badge.svc.label() : ""
+        font.family: badge.theme.iconFont
+        font.pixelSize: 11
+        font.weight: Font.DemiBold
+        color: badge.theme.accent
+    }
+}

--- a/features/hm/wayland/quickshell/task-bar/lib/modefmt.js
+++ b/features/hm/wayland/quickshell/task-bar/lib/modefmt.js
@@ -4,7 +4,7 @@
 
 // Hex codepoint string -> glyph, or "" when there is nothing valid to draw.
 // The guard matters: parseInt("zz", 16) is NaN and String.fromCharCode(NaN) is
-// " ", which paints a garbage box instead of drawing nothing.
+// U+0000, which paints a garbage box instead of drawing nothing.
 function glyphFor(cp) {
     if (cp === null || cp === undefined)
         return "";

--- a/features/hm/wayland/quickshell/task-bar/lib/modefmt.js
+++ b/features/hm/wayland/quickshell/task-bar/lib/modefmt.js
@@ -1,0 +1,18 @@
+// Pure helpers for the submap mode indicator. Plain top-level JS so it is both a
+// QML JS resource (import "../lib/modefmt.js" as ModeFmt) and readable by the
+// Deno test via indirect eval. Do NOT add `.pragma library`.
+
+// Hex codepoint string -> glyph, or "" when there is nothing valid to draw.
+// The guard matters: parseInt("zz", 16) is NaN and String.fromCharCode(NaN) is
+// " ", which paints a garbage box instead of drawing nothing.
+function glyphFor(cp) {
+    if (cp === null || cp === undefined)
+        return "";
+    var s = String(cp).trim();
+    if (s === "" || !/^[0-9a-fA-F]+$/.test(s))
+        return "";
+    var n = parseInt(s, 16);
+    if (isNaN(n))
+        return "";
+    return String.fromCharCode(n);
+}

--- a/features/hm/wayland/quickshell/task-bar/lib/modefmt.test.js
+++ b/features/hm/wayland/quickshell/task-bar/lib/modefmt.test.js
@@ -1,0 +1,26 @@
+// Deno test: indirect-eval the dual-use JS resource, then assert.
+// Run: deno test --allow-read lib/modefmt.test.js
+import { assertEquals } from "https://deno.land/std/assert/mod.ts";
+
+const code = await Deno.readTextFile(new URL("./modefmt.js", import.meta.url));
+const load = eval; // indirect eval -> global scope
+load(code);
+
+Deno.test("glyphFor converts a hex codepoint to its glyph", () => {
+  assertEquals(glyphFor("f065"), String.fromCharCode(0xf065));
+  assertEquals(glyphFor("F065"), String.fromCharCode(0xf065));
+});
+
+Deno.test("glyphFor returns empty string for absent input", () => {
+  assertEquals(glyphFor(""), "");
+  assertEquals(glyphFor(null), "");
+  assertEquals(glyphFor(undefined), "");
+});
+
+// A bad codepoint must render as nothing, not as U+0000. parseInt("zz", 16) is
+// NaN and String.fromCharCode(NaN) is " ", which paints a garbage box.
+Deno.test("glyphFor rejects non-hex input instead of emitting U+0000", () => {
+  assertEquals(glyphFor("zz"), "");
+  assertEquals(glyphFor("not-a-codepoint"), "");
+  assertEquals(glyphFor("  "), "");
+});

--- a/features/hm/wayland/quickshell/task-bar/modebadge-test.qml
+++ b/features/hm/wayland/quickshell/task-bar/modebadge-test.qml
@@ -1,0 +1,149 @@
+// Headless check for lib/ModeBadge.qml. Run:
+//     quickshell -p modebadge-test.qml
+//
+// Lives at the config ROOT rather than beside the component: `quickshell -p`
+// makes the entrypoint's parent the root, and lib/ModeBadge.qml does
+// `import "modefmt.js" as ModeFmt`, which only resolves from inside that root
+// (same reasoning as wakeservice-test.qml and routerpopup-size-test.qml).
+//
+// Wraps the badge in a Lib.Pill, mirroring how desktop/ModePill.qml (and the
+// coming desktop/ModeOverlay.qml) actually use it, with a stub theme carrying
+// every token Lib.Pill and Lib.ModeBadge read off it. Lib.BarText itself reads
+// the BarStyle singleton rather than theme, so nothing further is needed for
+// it. Creates no PanelWindow, so it maps no Wayland surface.
+import QtQuick
+import Quickshell
+import "lib" as Lib
+
+ShellRoot {
+    id: harness
+
+    property int pass: 0
+    property int fail: 0
+    function check(name, cond, detail) {
+        if (cond) { harness.pass++; console.log("  ok   " + name + "   " + (detail || "")); }
+        else { harness.fail++; console.log("  FAIL " + name + "   " + (detail || "")); }
+    }
+
+    QtObject {
+        id: stubTheme
+        readonly property color bgPill: "#282828"
+        readonly property color border: "#595959"
+        readonly property color accent: "#87b158"
+        readonly property string faFont: "Font Awesome 7 Free Solid"
+        readonly property string iconFont: "JetBrainsMono Nerd Font"
+    }
+
+    // A valid hex codepoint (fa-desktop, U+F108) with a label that changes
+    // mid-run, to prove the badge tracks svc.label() live rather than
+    // snapshotting it at creation.
+    QtObject {
+        id: svcValid
+        property string cp: "f108"
+        property string lbl: "Resize"
+        function iconCp() { return svcValid.cp; }
+        function label() { return svcValid.lbl; }
+    }
+
+    // Malformed codepoint: the guard Task 1 put in glyphFor, replacing the old
+    // ModePill.qml's direct String.fromCharCode(parseInt(...)) call, which
+    // painted a garbage glyph (U+0000) instead of drawing nothing.
+    QtObject {
+        id: svcMalformed
+        readonly property string cp: "not-hex"
+        function iconCp() { return svcMalformed.cp; }
+        function label() { return "Broken"; }
+    }
+
+    // Empty codepoint: the ordinary "this submap has no icon" case.
+    QtObject {
+        id: svcEmpty
+        readonly property string cp: ""
+        function iconCp() { return svcEmpty.cp; }
+        function label() { return "NoIcon"; }
+    }
+
+    Lib.Pill {
+        id: pillValid
+        theme: stubTheme
+        ringColor: stubTheme.accent
+        Lib.ModeBadge { id: badgeValid; theme: stubTheme; svc: svcValid }
+    }
+    Lib.Pill {
+        id: pillMalformed
+        theme: stubTheme
+        ringColor: stubTheme.accent
+        Lib.ModeBadge { id: badgeMalformed; theme: stubTheme; svc: svcMalformed }
+    }
+    Lib.Pill {
+        id: pillEmpty
+        theme: stubTheme
+        ringColor: stubTheme.accent
+        Lib.ModeBadge { id: badgeEmpty; theme: stubTheme; svc: svcEmpty }
+    }
+    // svc is null before HyprSubmapService's first Hyprland event lands;
+    // ModeBadge must not throw or render junk while it is.
+    Lib.Pill {
+        id: pillNull
+        theme: stubTheme
+        ringColor: stubTheme.accent
+        Lib.ModeBadge { id: badgeNull; theme: stubTheme; svc: null }
+    }
+
+    // ModeBadge declares its two BarText children in fixed order: the glyph
+    // first, the label second. Neither is given an id (the brief's ModeBadge.qml
+    // is used verbatim), so index into the RowLayout's visual children instead.
+    function glyphItem(badge) { return badge.children[0]; }
+    function labelItem(badge) { return badge.children[1]; }
+
+    Component.onCompleted: Qt.callLater(function () {
+        console.log("MODEBADGE-TEST");
+
+        // Font Awesome's private-use-area glyphs render invisibly in a plain
+        // terminal, so log the codepoint rather than the raw character.
+        function cpOf(s) { return s.length ? "U+" + s.charCodeAt(0).toString(16) : "(empty)"; }
+
+        // --- a valid hex codepoint produces a non-empty glyph -------------
+        harness.check("valid cp yields a non-empty glyph",
+                       badgeValid.glyph !== "", "glyph=" + cpOf(badgeValid.glyph));
+        harness.check("valid cp glyph matches String.fromCharCode(0xf108)",
+                       badgeValid.glyph === String.fromCharCode(0xf108),
+                       "glyph=" + cpOf(badgeValid.glyph));
+        harness.check("valid cp glyph BarText is visible",
+                       harness.glyphItem(badgeValid).visible === true);
+        harness.check("valid cp glyph BarText text matches badge.glyph",
+                       harness.glyphItem(badgeValid).text === badgeValid.glyph);
+
+        // --- malformed codepoint produces no glyph -------------------------
+        harness.check("malformed cp yields an empty glyph",
+                       badgeMalformed.glyph === "", "glyph=" + cpOf(badgeMalformed.glyph));
+        harness.check("malformed cp glyph BarText is not visible",
+                       harness.glyphItem(badgeMalformed).visible === false);
+        harness.check("malformed cp does not paint U+0000 (the bug Task 1 fixed)",
+                       harness.glyphItem(badgeMalformed).text !== String.fromCharCode(0));
+
+        // --- empty codepoint is the same as malformed, not a crash ---------
+        harness.check("empty cp yields an empty glyph",
+                       badgeEmpty.glyph === "");
+        harness.check("empty cp glyph BarText is not visible",
+                       harness.glyphItem(badgeEmpty).visible === false);
+
+        // --- svc: null is guarded, not a binding error ----------------------
+        harness.check("null svc yields an empty glyph",
+                       badgeNull.glyph === "");
+        harness.check("null svc glyph BarText is not visible",
+                       harness.glyphItem(badgeNull).visible === false);
+        harness.check("null svc label is empty, not a thrown error",
+                       harness.labelItem(badgeNull).text === "");
+
+        // --- the label tracks svc.label(), including live changes ----------
+        harness.check("label text tracks svc.label() at creation",
+                       harness.labelItem(badgeValid).text === "Resize");
+        svcValid.lbl = "Group";
+        harness.check("label text tracks svc.label() after it changes",
+                       harness.labelItem(badgeValid).text === "Group");
+
+        console.log("MODEBADGE-TEST " + harness.pass + "/" + (harness.pass + harness.fail));
+        Qt.exit(harness.fail === 0 ? 0 : 1);
+    });
+}

--- a/features/hm/wayland/quickshell/task-bar/modebadge-test.qml
+++ b/features/hm/wayland/quickshell/task-bar/modebadge-test.qml
@@ -1,10 +1,12 @@
 // Headless check for lib/ModeBadge.qml. Run:
 //     quickshell -p modebadge-test.qml
 //
-// Lives at the config ROOT rather than beside the component: `quickshell -p`
-// makes the entrypoint's parent the root, and lib/ModeBadge.qml does
-// `import "modefmt.js" as ModeFmt`, which only resolves from inside that root
-// (same reasoning as wakeservice-test.qml and routerpopup-size-test.qml).
+// Lives at the config ROOT (not beside the component): `quickshell -p` makes
+// the entrypoint's parent the config root. That placement is not what makes
+// lib/ModeBadge.qml's `import "modefmt.js" as ModeFmt` resolve, though: like
+// any relative QML import, it resolves relative to ModeBadge.qml's own
+// directory (lib/), regardless of where the entrypoint sits (same reasoning
+// as modeoverlay-test.qml, wakeservice-test.qml and routerpopup-size-test.qml).
 //
 // Wraps the badge in a Lib.Pill, mirroring how desktop/ModePill.qml (and the
 // coming desktop/ModeOverlay.qml) actually use it, with a stub theme carrying

--- a/features/hm/wayland/quickshell/task-bar/modeoverlay-test.qml
+++ b/features/hm/wayland/quickshell/task-bar/modeoverlay-test.qml
@@ -1,0 +1,129 @@
+// Headless construction check for desktop/ModeOverlay.qml. Run:
+//     quickshell -p modeoverlay-test.qml
+//
+// Lives at the config ROOT (not a subdirectory): `quickshell -p` makes the
+// entrypoint's parent the config root, and desktop/ModeOverlay.qml does
+// `import "../lib" as Lib`, which resolves relative to ModeOverlay.qml's own
+// directory regardless of where the entrypoint sits (same reasoning as
+// modebadge-test.qml and routerpopup-size-test.qml).
+//
+// This is a CONSTRUCTION harness only. It proves the component builds without
+// a QML error or warning -- a wrong import, a misspelled Wayland enum
+// (WlrKeyboardFocus.None, WlrLayer.Overlay, ExclusionMode.Ignore), an
+// unresolved Region -- and that the visibility predicate stays FALSE across
+// every combination this file drives.
+//
+// It does NOT map a real Overlay-layer surface. Every instance below is
+// pinned covered: false for the whole run, so `visible` can never evaluate
+// true: mapping that surface would paint above the user's live desktop,
+// including any fullscreen window, and this harness has no screen to observe
+// the result on. Exercising the visible-true case (a real submap plus a real
+// fullscreen window, checked with `hyprctl layers`) is Task 5's job, done
+// interactively by a human on the live compositor, not here.
+import QtQuick
+import Quickshell
+import "desktop" as Desktop
+
+ShellRoot {
+    id: harness
+
+    property int pass: 0
+    property int fail: 0
+    function check(name, cond, detail) {
+        if (cond) { harness.pass++; console.log("  ok   " + name + "   " + (detail || "")); }
+        else { harness.fail++; console.log("  FAIL " + name + "   " + (detail || "")); }
+    }
+
+    // Stub theme carrying every token Lib.Pill and Lib.ModeBadge read off it,
+    // matching modebadge-test.qml's stub.
+    QtObject {
+        id: stubTheme
+        readonly property color bgPill: "#282828"
+        readonly property color border: "#595959"
+        readonly property color accent: "#87b158"
+        readonly property string faFont: "Font Awesome 7 Free Solid"
+        readonly property string iconFont: "JetBrainsMono Nerd Font"
+    }
+
+    // An "active submap" stub (non-empty current) so that in the covered:false
+    // cases below, the ONLY reason visible must stay false is the covered
+    // gate itself, not an incidentally-empty svc.
+    QtObject {
+        id: svcActive
+        readonly property string current: "resize"
+        function iconCp() { return "f108"; }
+        function label() { return "Resize"; }
+    }
+
+    // The ordinary idle state: no submap active.
+    QtObject {
+        id: svcIdle
+        readonly property string current: ""
+        function iconCp() { return ""; }
+        function label() { return ""; }
+    }
+
+    // Four instances spanning svc x locked. ALL four are covered: false for
+    // the entire run -- see the HARD REQUIREMENT in the file header. This is
+    // deliberately not the full covered x svc x locked matrix; the
+    // covered:true leg is Task 5's, not this harness's.
+    Desktop.ModeOverlay {
+        id: ovActiveUnlocked
+        theme: stubTheme
+        svc: svcActive
+        covered: false
+        locked: false
+        barHeight: 34
+    }
+    Desktop.ModeOverlay {
+        id: ovActiveLocked
+        theme: stubTheme
+        svc: svcActive
+        covered: false
+        locked: true
+        barHeight: 34
+    }
+    Desktop.ModeOverlay {
+        id: ovIdleUnlocked
+        theme: stubTheme
+        svc: svcIdle
+        covered: false
+        locked: false
+        barHeight: 34
+    }
+    Desktop.ModeOverlay {
+        id: ovIdleLocked
+        theme: stubTheme
+        svc: svcIdle
+        covered: false
+        locked: true
+        barHeight: 34
+    }
+
+    Component.onCompleted: Qt.callLater(function () {
+        console.log("MODEOVERLAY-TEST");
+
+        harness.check("active submap, unlocked, NOT covered stays hidden",
+                       ovActiveUnlocked.visible === false,
+                       "visible=" + ovActiveUnlocked.visible);
+        harness.check("active submap, locked, not covered stays hidden",
+                       ovActiveLocked.visible === false,
+                       "visible=" + ovActiveLocked.visible);
+        harness.check("idle submap, unlocked, not covered stays hidden",
+                       ovIdleUnlocked.visible === false,
+                       "visible=" + ovIdleUnlocked.visible);
+        harness.check("idle submap, locked, not covered stays hidden",
+                       ovIdleLocked.visible === false,
+                       "visible=" + ovIdleLocked.visible);
+
+        // implicitHeight tracks the bound barHeight without restating it (44
+        // in the real shell, off taskbar.implicitHeight); 34 here just proves
+        // the binding rather than hardcoding the real constant.
+        harness.check("implicitHeight tracks the bound barHeight",
+                       ovActiveUnlocked.implicitHeight === 34,
+                       "implicitHeight=" + ovActiveUnlocked.implicitHeight);
+
+        console.log("MODEOVERLAY-TEST " + harness.pass + "/" + (harness.pass + harness.fail));
+        Qt.exit(harness.fail === 0 ? 0 : 1);
+    });
+}

--- a/features/hm/wayland/quickshell/task-bar/modeoverlay-test.qml
+++ b/features/hm/wayland/quickshell/task-bar/modeoverlay-test.qml
@@ -22,6 +22,7 @@
 // interactively by a human on the live compositor, not here.
 import QtQuick
 import Quickshell
+import Quickshell.Wayland
 import "desktop" as Desktop
 
 ShellRoot {
@@ -115,6 +116,27 @@ ShellRoot {
         harness.check("idle submap, locked, not covered stays hidden",
                        ovIdleLocked.visible === false,
                        "visible=" + ovIdleLocked.visible);
+
+        // The four checks above are near-tautological on their own: every
+        // instance is pinned covered: false, which alone forces visible ===
+        // false regardless of anything else. The checks below are the
+        // load-bearing ones for an unmapped window -- they prove the
+        // layer-shell configuration itself actually resolved (right layer,
+        // no keyboard focus, right namespace, an empty input region), since a
+        // misspelled enum or a missing Region would silently break layering
+        // or click-through without ever failing a visible === false check.
+        harness.check("layer is WlrLayer.Overlay",
+                       ovActiveUnlocked.WlrLayershell.layer === WlrLayer.Overlay,
+                       "layer=" + ovActiveUnlocked.WlrLayershell.layer);
+        harness.check("keyboardFocus is WlrKeyboardFocus.None",
+                       ovActiveUnlocked.WlrLayershell.keyboardFocus === WlrKeyboardFocus.None,
+                       "keyboardFocus=" + ovActiveUnlocked.WlrLayershell.keyboardFocus);
+        harness.check("namespace is quickshell:mode",
+                       ovActiveUnlocked.WlrLayershell.namespace === "quickshell:mode",
+                       "namespace=" + ovActiveUnlocked.WlrLayershell.namespace);
+        harness.check("mask is set (empty input region for click-through)",
+                       ovActiveUnlocked.mask !== null,
+                       "mask=" + ovActiveUnlocked.mask);
 
         // implicitHeight tracks the bound barHeight without restating it (44
         // in the real shell, off taskbar.implicitHeight); 34 here just proves

--- a/features/hm/wayland/quickshell/task-bar/shell.qml
+++ b/features/hm/wayland/quickshell/task-bar/shell.qml
@@ -331,6 +331,20 @@ ShellRoot {
                 wakeSvc: resumeMonitor
             }
 
+            // Submap indicator for a monitor whose bar is covered by a
+            // fullscreen window. Sibling of the taskbar so it can read that
+            // bar's own surfaceVisible and height directly; both are per
+            // monitor, so a fullscreen app on one output leaves the other
+            // showing its normal rightRow pill.
+            Desktop.ModeOverlay {
+                screen: v.modelData
+                theme: screenTheme
+                svc: submapSvc
+                covered: !taskbar.surfaceVisible
+                locked: lockScreen.locked || lockScreen.captureArmed
+                barHeight: taskbar.implicitHeight
+            }
+
             // The Hub overlay (SUPER+Right-Alt). Hyprland binds that key to a
             // `global, quickshell:hubToggle` dispatch (see hyprland.nix hubBind),
             // which fires the single ShellRoot GlobalShortcut; that toggles the


### PR DESCRIPTION
- **feat(task-bar): add guarded glyphFor helper for the submap badge**
- **refactor(task-bar): extract the submap badge into lib/ModeBadge**
- **feat(task-bar): pulse the submap pill in the accent colour**
- **feat(task-bar): show the submap badge over fullscreen windows**
- **fix(task-bar): gate the pill pulse timer and fix maximize false positive**
