### PR TITLE
Fix/qs lockscreen fixes

### DIFF
--- a/features/hm/wayland/hypr-wl-debug.nix
+++ b/features/hm/wayland/hypr-wl-debug.nix
@@ -41,12 +41,20 @@
   # different command line would make the watchdog declare every legitimate lock
   # stranded and unlock it.
   #
-  # quickshell is deliberately NOT in runtimeInputs and `qs` is deliberately
-  # unqualified. ./quickshell.nix installs an overrideAttrs of pkgs.quickshell,
-  # not pkgs.quickshell itself, so putting the latter on PATH shadows the profile
-  # binary and the traced session fails to load the lock backdrop's
-  # Qt5Compat.GraphicalEffects import. Letting PATH resolve it is what makes both
-  # branches provably the same binary.
+  # `qs` is deliberately unqualified, so the traced branch provably runs the
+  # same binary as the untraced one below.
+  #
+  # This used to also be a correctness requirement: ./quickshell.nix installed
+  # an overrideAttrs of pkgs.quickshell rather than pkgs.quickshell itself, so
+  # naming the latter shadowed the profile binary and the traced session died
+  # on the lock backdrop's Qt5Compat.GraphicalEffects import. That is no longer
+  # true -- the qt5compat buildInput, the runtime-deps PATH prefix and both
+  # patches now live in the `quickshellPatched` overlay (helpers/overlays.nix,
+  # listed in baseDesktop), so pkgs.quickshell IS the patched package for both
+  # NixOS and home-manager. Verified 2026-08-16: nixosConfigurations.thanatos
+  # and homeConfigurations."michael-thanatos" evaluate pkgs.quickshell to the
+  # same drv. Leaving `qs` unqualified is now a simplicity choice, not a trap
+  # being avoided.
   tracedBar = pkgs.writeShellApplication {
     name = "qs-bar-traced";
     runtimeInputs = [pkgs.coreutils];

--- a/features/hm/wayland/hyprland.nix
+++ b/features/hm/wayland/hyprland.nix
@@ -714,15 +714,28 @@ in {
               };
             };
 
-            # Hyprland's own logging is off by default and cannot be enabled at
-            # runtime, so hyprland.log normally carries only aquamarine chatter
-            # and the protocol error that destroys the quickshell client leaves
-            # no compositor-side trace. Read from the environment at parse time
-            # so the debug session entry (features/nixos/desktop/wayland/
-            # hyprland-wldebug.nix) can ask for full logs and the normal session
-            # is untouched.
+            # Hyprland's own logging, UNCONDITIONALLY on.
+            #
+            # This used to be gated on HYPR_WL_DEBUG so only the Wayland-debug
+            # session paid for it. That gate cost two investigations. When the
+            # compositor posts a protocol error and destroys the quickshell
+            # client, the ONLY compositor-side record is Hyprland's own log
+            # line naming the interface -- and with logging off, hyprland.log
+            # is 99.8% aquamarine chatter (measured 2026-08-16: 11021 of 11043
+            # lines; the 22 Hyprland lines were all emitted before this option
+            # was parsed). So a death in the normal session cannot be
+            # attributed at all, and the flag is latched at startup:
+            # `hyprctl eval 'hl.config({debug = {disable_logs = false}})'`
+            # reports success, getoption then reads false, and no new lines
+            # appear. Verified by adding and removing an output and counting.
+            #
+            # The cost is nothing like WAYLAND_DEBUG's line per request and
+            # event -- this is a few thousand lines over a session, and
+            # hyprland.log already lives in the runtime dir and dies with it.
+            # Paying that always is a far better trade than losing the next
+            # incident, which is what happened on 2026-08-16.
             debug = {
-              disable_logs = mkLuaInline ''os.getenv("HYPR_WL_DEBUG") ~= "1"'';
+              disable_logs = false;
             };
 
             misc = {

--- a/features/hm/wayland/quickshell-lock.nix
+++ b/features/hm/wayland/quickshell-lock.nix
@@ -12,7 +12,10 @@ let
     name = "lock-escape";
     # appRun so the relaunch resolves app-run hermetically rather than off
     # whatever PATH the compositor happens to hand the keybind.
-    runtimeInputs = [ pkgs.quickshell pkgs.procps pkgs.coreutils appRun ];
+    # systemd for `systemctl --user show-environment`: the script re-reads the
+    # session's live display environment because a unit that started before
+    # uwsm finalize has none of its own (see the note in lock-escape.sh).
+    runtimeInputs = [ pkgs.quickshell pkgs.procps pkgs.coreutils pkgs.systemd appRun ];
     text = builtins.readFile ./quickshell/task-bar/lock/lock-escape.sh;
   };
 in {

--- a/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
+++ b/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
@@ -1,14 +1,86 @@
 # Dev escape hatch: return the session to UNLOCKED, whatever the lock's state.
-# 1) graceful IPC unlock if the shell is alive; 2) else relaunch the shell with
-# QS_LOCK_ESCAPE=1 so Lock.qml acquires-then-releases the stranded lock
-# (requires misc:allow_session_lock_restore = true).
+# 1) if the shell is alive, drive it over IPC to acquire-then-release the lock;
+# 2) else relaunch the shell with QS_LOCK_ESCAPE=1 so Lock.qml does the same
+# from Component.onCompleted. Both paths need misc:allow_session_lock_restore,
+# because reclaiming a lock whose original client is gone IS a restore.
 # NB: packaged via writeShellApplication, which injects the shebang and
 # `set -euo pipefail` and runs shellcheck -- so no shebang here, and guard
 # commands that may exit non-zero (pkill with no match) with `|| true`.
 
 CFG="task-bar"
 
-if qs -c "$CFG" ipc call lock unlock 2>/dev/null; then
+# Re-read the session's live environment instead of trusting what we inherited.
+#
+# A systemd unit's PROCESS environment is captured once, when the unit starts.
+# uwsm publishes WAYLAND_DISPLAY / HYPRLAND_INSTANCE_SIGNATURE into the user
+# MANAGER's environment at finalize time, so a unit that started before that
+# keeps an environment with no display in it for the rest of the session.
+# qs-lock-watchdog.service lost exactly that race on 2026-08-16 (unit started
+# 23:29:34, the same second as uwsm's env-preloader) and carried 44 vars with
+# no WAYLAND_DISPLAY. The relaunch below inherited that, Qt fell back to the
+# xcb platform plugin, found no X server, and died with "no Qt platform plugin
+# could be initialized" -- two coredumps and a session left with no bar, from
+# the recovery path that exists to prevent exactly that.
+#
+# Reading the manager's environment here is immune to unit start order, which
+# is the actual defect. Explicit per-variable assignment rather than eval of
+# the whole block: show-environment emits $'...' shell quoting for values that
+# need it, and blindly exporting those would set the literal text.
+live_env() {
+    # Trailing `|| true` is load-bearing: writeShellApplication runs this under
+    # `set -euo pipefail`, so a systemctl that cannot reach the user manager
+    # would abort lock-escape right here -- silently, and before the explicit
+    # refusal below could say why.
+    systemctl --user show-environment 2>/dev/null | sed -n "s/^$1=//p" | head -1 || true
+}
+
+for _var in WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_RUNTIME_DIR; do
+    _val="$(live_env "$_var")"
+    if [ -n "$_val" ]; then
+        case "$_var" in
+            WAYLAND_DISPLAY) export WAYLAND_DISPLAY="$_val" ;;
+            HYPRLAND_INSTANCE_SIGNATURE) export HYPRLAND_INSTANCE_SIGNATURE="$_val" ;;
+            XDG_RUNTIME_DIR) export XDG_RUNTIME_DIR="$_val" ;;
+        esac
+    fi
+done
+unset _var _val
+
+# Without a display there is nothing to unlock and a relaunch would only
+# reproduce the abort above. Fail loudly rather than leaving a silent crash
+# loop in the journal.
+if [ -z "${WAYLAND_DISPLAY:-}" ]; then
+    echo "lock-escape: no WAYLAND_DISPLAY in this process or in the systemd user environment; refusing to relaunch" >&2
+    exit 1
+fi
+
+# ACQUIRE, THEN RELEASE -- releasing alone is not enough, and that is what
+# left the session stranded on 2026-08-16.
+#
+# The compositor's ext_session_lock outlives the client that took it. When the
+# shell dies while holding the lock, Hyprland keeps showing its solid-colour
+# fallback and a NEW shell does not inherit that lock -- it simply starts up
+# unlocked, holding nothing. A bare `unlock` then reports success (there is
+# nothing for it to do) while the screen stays stuck, and this script exited 0
+# believing it had recovered. Verified live: with the fallback on screen and a
+# healthy bar running, `call lock unlock` returned success and changed
+# nothing; `call lock lock` followed by `call lock unlock` cleared it. The
+# `lock` re-acquires the stranded lock into the live client (a session-lock
+# restore, which is why misc:allow_session_lock_restore must be true) and the
+# `unlock` then destroys it properly. That is the same acquire-then-release
+# the QS_LOCK_ESCAPE relaunch below performs; doing it over IPC just avoids
+# restarting a perfectly healthy shell.
+#
+# Address the shell by PID, not by `-c "$CFG"`. Dead instances leave their
+# entries under $XDG_RUNTIME_DIR/quickshell/by-pid, and once more than one is
+# registered for a config name `ipc call` refuses to pick and prints the
+# candidate list instead of acting -- observed with four stale entries.
+shell_pid="$(pgrep -f "quickshell -c $CFG" | head -1 || true)"
+
+if [ -n "$shell_pid" ] \
+    && qs ipc --pid "$shell_pid" call lock lock >/dev/null 2>&1 \
+    && sleep 0.3 \
+    && qs ipc --pid "$shell_pid" call lock unlock >/dev/null 2>&1; then
     exit 0
 fi
 
@@ -18,10 +90,21 @@ fi
 # `quickshell -c task-bar` command line is comm-truncation-proof.
 pkill -f 'quickshell -c task-bar' 2>/dev/null || true
 sleep 0.3
-# Same placement as the autostart hook (hyprland.nix): -s b puts the recovered
-# bar in background-graphical.slice, so it keeps the memory.low protection the
-# normally-started one gets (nixos/thanatos/memory.nix). Without app-run the
-# escape-path bar would be the one process left in the compositor's cgroup.
+# Same placement as the autostart hook (hyprland.nix): -s b ASKS for
+# background-graphical.slice so the recovered bar keeps the memory.low
+# protection the normally-started one gets (nixos/thanatos/memory.nix).
+#
+# Do not assume it lands there. app-run only takes its uwsm branch when
+# UWSM_FINALIZE_VARNAMES is set, and that comes from uwsm's per-compositor
+# quirks plugin, which uwsm selects by basename(Exec[0]) -- so a session
+# launched through a wrapper gets no plugin, no variable, and app-run silently
+# degrades to plain `exec "$@"`. When that happened the recovered bar simply
+# inherited THIS script's cgroup, i.e. qs-lock-watchdog.service, and a
+# home-manager switch restarting that unit killed the bar with it
+# (KillMode=control-group). Fixed at the source in
+# ../../../../../nixos/desktop/wayland/hyprland-wldebug.nix by naming the
+# wrapper start-hyprland, but the degradation is silent, so treat placement
+# here as best-effort rather than guaranteed.
 # app2unit uses `systemd-run --scope`, which execs in place, so QS_LOCK_ESCAPE
 # is inherited by the scope -- the whole point of this relaunch. The scope name
 # carries a random suffix, so it cannot collide with a stale one.

--- a/features/nixos/desktop/wayland/hyprland-wldebug.nix
+++ b/features/nixos/desktop/wayland/hyprland-wldebug.nix
@@ -17,12 +17,19 @@
 # debug session that has silently become either broken or identical to the
 # normal one would read as "the bug did not reproduce".
 #
-# The Hyprland config cannot drift either: there is only one, and the single
-# difference it makes is read from the environment at parse time
-# (debug.disable_logs, gated on HYPR_WL_DEBUG -- see ../../../hm/wayland/
-# hyprland.nix; the flag cannot be flipped at runtime, hence an env var).
-# ../../../hm/wayland/hypr-wl-debug.nix reads the same variable and starts the
-# bar under WAYLAND_DEBUG=client with the output ring-buffered.
+# The Hyprland config cannot drift either: there is only one, and as of
+# 2026-08-16 it makes NO difference between the two sessions at all.
+# debug.disable_logs used to be gated on HYPR_WL_DEBUG so only this session got
+# Hyprland's own logs; that gate meant a protocol-error death in the normal
+# session could not be attributed to an interface, which cost two
+# investigations, so ../../../hm/wayland/hyprland.nix now sets it false
+# unconditionally. Both sessions therefore get compositor logging.
+#
+# What this session still buys, and the only thing it buys:
+# ../../../hm/wayland/hypr-wl-debug.nix reads HYPR_WL_DEBUG and starts the bar
+# under WAYLAND_DEBUG=client with the output ring-buffered -- a line per
+# Wayland request and event, which names the offending object rather than only
+# the interface. That is the expensive half and stays opt-in at login.
 {
   config,
   lib,

--- a/flake.lock
+++ b/flake.lock
@@ -1245,6 +1245,26 @@
         "type": "github"
       }
     },
+    "idrive-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786863096,
+        "narHash": "sha256-pjOvvn6an+rbgByCskqeWSJaiYPBDkY1VsOXDd1E57k=",
+        "owner": "MichaelPachec0",
+        "repo": "idrive-nix",
+        "rev": "1fe7ef8522d3b3e5f2b564f785aec4c320c26fb2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MichaelPachec0",
+        "repo": "idrive-nix",
+        "type": "github"
+      }
+    },
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager_3",
@@ -2149,6 +2169,7 @@
         "hardware": "hardware",
         "home-manager": "home-manager_2",
         "home-manager-stable": "home-manager-stable",
+        "idrive-nix": "idrive-nix",
         "impermanence": "impermanence",
         "jlink": "jlink",
         "joshuto": "joshuto",

--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,10 @@
       url = "github:MichaelPachec0/Gruvbox-GTK-Theme";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    idrive-nix = {
+      url = "github:MichaelPachec0/idrive-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {

--- a/helpers/overlays.nix
+++ b/helpers/overlays.nix
@@ -309,55 +309,6 @@
         patches = (old.patches or []) ++ [../overlays/kdeconnect-inputcapture-barrier-type.patch];
       });
     });
-    # Patch Quickshell: the forked PAM subprocess frees the caller's
-    # `pam_response**` out-param (a stack address) on any IPC write failure, so
-    # a shell that dies while a PAM child is still blocked in pam_fprintd turns
-    # into a bogus "quickshell crashed" SIGSEGV report. Unfixed upstream as of
-    # 28771c7. Patched at the TOP-LEVEL `quickshell` so the raw `pkgs.quickshell`
-    # uses (swayidle.nix, quickshell-lock.nix) and the HM module's own
-    # overrideAttrs (features/hm/wayland/quickshell.nix) all stack on the fix.
-    #
-    # Second patch: a ScreencopyView created before its item is in a scene
-    # latches WlBufferManager permanently (the retry guard is a never-reset
-    # function-static), so no capture ever starts and no screencopy protocol is
-    # bound. That is exactly the lock backdrop's per-output pool, whose
-    # delegates are reparented into place only after the lock engages, so the
-    # backdrop silently falls back to the wallpaper on every lock until the
-    # config is reloaded. Also unfixed upstream as of 28771c7.
-    quickshell = prev.quickshell.overrideAttrs (old: {
-      buildInputs = (old.buildInputs or []) ++ [final.qt6.qt5compat];
-      # wrapQtAppsHook applies these when wrapping bin/qs and bin/quickshell, so the
-      # shell's child processes (bash -lc lib/*.sh) inherit the deps on PATH.
-      qtWrapperArgs = let
-        runtimeDeps = with final; [
-          bash
-          coreutils
-          gnugrep
-          gnused
-          gawk
-          bluez # bluetoothctl
-          pipewire # pw-dump
-          wireplumber # wpctl
-          pulseaudio # pactl
-          python3
-          systemd # busctl (mpris-extra.sh)
-          pbpctrl # Pixel Buds control (btinfo.sh pbp/set)
-          wl-clipboard # wl-copy (network widget middle-click copy)
-          networkmanager # nmcli (NetworkService)
-          iproute2 # ip (NetworkService default-route lookup)
-          awww
-          # config.services.awww.package # awww query (LockBackdrop reads per-output wallpaper)
-        ];
-      in
-        (old.qtWrapperArgs or [])
-        ++ ["--prefix PATH : ${prev.lib.makeBinPath runtimeDeps}"];
-      patches =
-        (old.patches or [])
-        ++ [
-          ../overlays/quickshell-pam-conversation-invalid-free.patch
-          ../overlays/quickshell-screencopy-buffer-manager-latch.patch
-        ];
-    });
     latest = {
       # nixpkgs ships Hyprland 0.56.0; the `hyprland` attr above bumps it to
       # v0.56.2 and carries the two crash patches. The old 0005 popup-coords
@@ -415,7 +366,88 @@
       };
     };
   };
+  # Quickshell, patched -- deliberately its OWN overlay, and listed in
+  # baseDesktop rather than in `latest`.
+  #
+  # It used to live inside the `latest` overlay, which is only in the two
+  # UNSTABLE bundles. But `pkgs.quickshell` has consumers reached from `base`:
+  # pkgs/qs-greeter/default.nix puts `quickshell` in the greeter's
+  # runtimeInputs, and the qsGreeter overlay is in `base`, i.e. in every bundle
+  # including the stable ones. So a stable desktop host resolved a
+  # `pkgs.quickshell` that had NONE of this applied -- no qt6.qt5compat, so the
+  # config dies at load with `module "Qt5Compat.GraphicalEffects" is not
+  # installed`, and no runtime deps on PATH for the shell's helper scripts.
+  # baseDesktop is the narrowest list that covers all four desktop bundles
+  # (stable/unstable x nixos/homeManager), so NixOS and home-manager now get
+  # the same binary by construction rather than by which channel they are on.
+  # Overlays are lazy: a host that never references quickshell builds nothing.
+  #
+  # Patch 1: the forked PAM subprocess frees the caller's `pam_response**`
+  # out-param (a stack address) on any IPC write failure, so a shell that dies
+  # while a PAM child is still blocked in pam_fprintd turns into a bogus
+  # "quickshell crashed" SIGSEGV report. Unfixed upstream as of 28771c7.
+  #
+  # Patch 2: a ScreencopyView created before its item is in a scene latches
+  # WlBufferManager permanently (the retry guard is a never-reset
+  # function-static), so no capture ever starts and no screencopy protocol is
+  # bound. That is exactly the lock backdrop's per-output pool, whose delegates
+  # are reparented into place only after the lock engages, so the backdrop
+  # silently falls back to the wallpaper on every lock until the config is
+  # reloaded. Also unfixed upstream as of 28771c7.
+  quickshellPatched = final: prev: {
+    # Patch Quickshell: the forked PAM subprocess frees the caller's
+    # `pam_response**` out-param (a stack address) on any IPC write failure, so
+    # a shell that dies while a PAM child is still blocked in pam_fprintd turns
+    # into a bogus "quickshell crashed" SIGSEGV report. Unfixed upstream as of
+    # 28771c7. Patched at the TOP-LEVEL `quickshell` so the raw `pkgs.quickshell`
+    # uses (swayidle.nix, quickshell-lock.nix) and the HM module's own
+    # overrideAttrs (features/hm/wayland/quickshell.nix) all stack on the fix.
+    #
+    # Second patch: a ScreencopyView created before its item is in a scene
+    # latches WlBufferManager permanently (the retry guard is a never-reset
+    # function-static), so no capture ever starts and no screencopy protocol is
+    # bound. That is exactly the lock backdrop's per-output pool, whose
+    # delegates are reparented into place only after the lock engages, so the
+    # backdrop silently falls back to the wallpaper on every lock until the
+    # config is reloaded. Also unfixed upstream as of 28771c7.
+    quickshell = prev.quickshell.overrideAttrs (old: {
+      buildInputs = (old.buildInputs or []) ++ [final.qt6.qt5compat];
+      # wrapQtAppsHook applies these when wrapping bin/qs and bin/quickshell, so the
+      # shell's child processes (bash -lc lib/*.sh) inherit the deps on PATH.
+      qtWrapperArgs = let
+        runtimeDeps = with final; [
+          bash
+          coreutils
+          gnugrep
+          gnused
+          gawk
+          bluez # bluetoothctl
+          pipewire # pw-dump
+          wireplumber # wpctl
+          pulseaudio # pactl
+          python3
+          systemd # busctl (mpris-extra.sh)
+          pbpctrl # Pixel Buds control (btinfo.sh pbp/set)
+          wl-clipboard # wl-copy (network widget middle-click copy)
+          networkmanager # nmcli (NetworkService)
+          iproute2 # ip (NetworkService default-route lookup)
+          awww
+          # config.services.awww.package # awww query (LockBackdrop reads per-output wallpaper)
+        ];
+      in
+        (old.qtWrapperArgs or [])
+        ++ ["--prefix PATH : ${prev.lib.makeBinPath runtimeDeps}"];
+      patches =
+        (old.patches or [])
+        ++ [
+          ../overlays/quickshell-pam-conversation-invalid-free.patch
+          ../overlays/quickshell-screencopy-buffer-manager-latch.patch
+        ];
+    });
+  };
+
   baseDesktop = [
+    quickshellPatched
     inputs.nix-vscode-extensions.overlays.default
     inputs.nix-your-shell.overlays.default
     inputs.rust-overlay.overlays.default

--- a/nixos/nyx/configuration.nix
+++ b/nixos/nyx/configuration.nix
@@ -35,6 +35,7 @@ in {
     ../../features/nixos/virtualization
     ../../features/nixos/common/deploy.nix
     inputs.nix-gaming.nixosModules.pipewireLowLatency
+    inputs.idrive-nix.nixosModules.idrive
   ];
   config = {
     boot.initrd.availableKernelModules = [
@@ -123,6 +124,7 @@ in {
     report-changes.enable = true;
     nixpkgs = {
       overlays = [
+        inputs.idrive-nix.overlays.default
       ];
       config = {
         allowUnfree = true;
@@ -1428,9 +1430,30 @@ in {
       workspaceId = "2f9183ef-deea-4c65-a514-add0f71aa92b";
       # toolProfile = "authoring";
     };
+    services.idrive = {
+      enable = false;
+      backupPaths = [
+        "/home/michael/Pictures/"
+      ];
+      usernameFile = config.sops.secrets."idrive/username".path;
+      passwordFile = config.sops.secrets."idrive/password".path;
+      encryptionKeyFile = config.sops.secrets."idrive/encryptionKey".path;
+    };
 
     sops.secrets."mcp/affine/username" = {};
     sops.secrets."mcp/affine/password" = {};
+    sops.secrets."idrive/username" = {
+      owner = config.services.idrive.user;
+      mode = "0400";
+    };
+    sops.secrets."idrive/password" = {
+      owner = config.services.idrive.user;
+      mode = "0400";
+    };
+    sops.secrets."idrive/encryptionKey" = {
+      owner = config.services.idrive.user;
+      mode = "0400";
+    };
     # 2f9183ef-deea-4c65-a514-add0f71aa92b
 
     # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion

--- a/secrets/default.yaml
+++ b/secrets/default.yaml
@@ -19,7 +19,7 @@ selene:
     conduwuit:
         registration_token: ENC[AES256_GCM,data:agx9JEag45TeE+VbwUc4ykYxwgHyKjsYIOUu6jwj3kcwUw6klyoJTDnbHS3hfBWpLFeL5XvT4KpamYDMol+8T0REu14hPB6D,iv:AqA0z6VtHKjgb4aJns8oq8YMipgQEvbWv9bx01xf2zI=,tag:sF4tnp73hkaVoAZCrDZuDw==,type:str]
     cloudflare:
-        api-token: ENC[AES256_GCM,data:jL2z3Fng79X71dZkvbJv77RT8G+iTqzFv8zLoZSk0XRiP/jiBUPFr54AagCwRTYwy/RW7YghQS2LdlH92qxxVeE=,iv:FCGhtfvjzmPhg7C7SVDIuM6ccMcC34I99yZAI7RWh8M=,tag:dvO8IJFZM0w4icJZUFsLkg==,type:str]
+        api-token: ENC[AES256_GCM,data:dJzDMJdVO2THvOcdCVR62Jk476wPECsIFkDUr3fgYiBZPWQWKKUqdbQOnbiPFYU247RvLqC3gzwuqaRDnAeKJan2,iv:igMHqODKjwcKxOd62rN8ohsJXGEiqpmWY3GSDcxyW2o=,tag:pcgeJdcMOFfwYsRKXwXyeA==,type:str]
     nginx:
         #ENC[AES256_GCM,data:cdKeRfYs2aGpXxGDwtV7LMWgIocDSDOaxdJHiVJeqx+iEpBfPZip0Om/TV4fKXK855OjsNY6oLsyvsm6YYU=,iv:bjqNNOHCp61OIJy1rQKEU2+b3kqoNyIsL4WJFZSSDsM=,tag:Ih8xXODqnCS/SyYe5W8QFQ==,type:comment]
         estevan: ENC[AES256_GCM,data:71qmHuvSMX30KPuLSXfZfFS3LzTPdq0d5VfgbH3RoJRbZtIehRkZXa2+xEV2/e3t66MHLXviEil2i5qsgBYCrjxBuVW7,iv:uOiJysU+29OYQPXCVv2ItzQH/KeQfTH8JEt2K8+994k=,tag:/pVddesRe+SWS2OUCs6JPw==,type:str]
@@ -41,6 +41,10 @@ mcp:
     affine:
         username: ENC[AES256_GCM,data:QhMZHdMXIUUaOKQVF+hR8StolcgEXw==,iv:785YZopUtVY465JIcNbnj+GRj/DDRtblag5bQC8Uv1c=,tag:Y1LTc/tqRcjvZsBtR0bqhA==,type:str]
         password: ENC[AES256_GCM,data:JZQJOfoLYKcYnUSgK4eyy1f8RIQv,iv:68Vt3/ll6BaeosNdB8YygK8MRk7514HMZutcPafzV28=,tag:T3VjJa779kQEAcKbeGWpVw==,type:str]
+idrive:
+    username: ENC[AES256_GCM,data:jwEBC8qA85J9YusWF/7NpnZ4lXws,iv:AqIXedO8zXK8+FrSWcpWY1DTQnyF0CdK8flCtEMxZ6E=,tag:6MCEzsP/KkhXAcNj4kASVQ==,type:str]
+    password: ENC[AES256_GCM,data:H65PciOUMSlwiz9GQR8pGUehs/75,iv:hQsuxoms7khxLT59MnoQh+CIOJKXV/erPp5T8QE4f+s=,tag:7t1mIWjZniuD1wdCYDvG3Q==,type:str]
+    encryptionKey: ENC[AES256_GCM,data:ip+ZAyLwblX2gKz1CbJK6YgbGSRdhac6cUa2KOh6de1IuvSRzuSlTxz9Pov3/v/dzAA9ERTiZdrxnIhUhpSOdEP8VkTzJd9FyUAiF1CWgDDha3EKHq7YWzAvtTSkbtny,iv:hM5KAtkZ9LBPvy7gfoYvTMpMzFedARYnddPp82TObzw=,tag:pQQ5YIzYCNge2L6awXFYdw==,type:str]
 sops:
     age:
         - enc: |
@@ -70,8 +74,8 @@ sops:
             riZjkfRUILPiNEKDsUEtnoHapsg5wSoAIO5Vyh7eElNQLaY0y80Drg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1jstnme4ukmd0cgw09xf53uh7f3lkh05mwrnt5lrs57z0xqgqwf2qh73f9l
-    lastmodified: "2026-07-24T10:46:41Z"
-    mac: ENC[AES256_GCM,data:0u0hZE9UolkJ5VllQXK4PMXddh81JInF7WyTKDqnFGA2HXzVcts2lLJPUs7e/HDdYYhv6AH3FoC0TA/4utFCht8wlhRHO2z0Vvzv+sI9QiLAt/0+j6TS7BQAm79gp4KCw3WkU2PUqvLZbcXXlUjOpQQh3nmm9XiFjQZqlOzDa68=,iv:Kwkmieh0Kt1IOqxXjmdboazVYrUNlwcvZL1m/nH1e5Q=,tag:RWk6Isn8LGUpYXB6mksZeQ==,type:str]
+    lastmodified: "2026-08-15T15:28:30Z"
+    mac: ENC[AES256_GCM,data:pXMUnhkXRLf5ofxI/wLmB31eID0zXC9BFJT6f8UNUaDSJco+TFr+jiwj1xyMbrCtMqhBqC7tfK93ZBU0Jk75nA65WeH75vkbzAx6gAJpfhGqPBRWAA6cCzlYJCdE83qVfV+xasDP1Bj+QAhPfmmh7rNj/FZrTkfSb4Y1Ccaf59k=,iv:p5iqm3h5BI1w6nMl7LDvGlYNkVwIbOkTB209FlVFX1o=,tag:Wfaw2euk+Bz4EpU0kmQJBg==,type:str]
     pgp:
         - created_at: "2025-06-28T01:32:12Z"
           enc: |-
@@ -94,4 +98,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 8d12991f5558c50170b2779c781146b0b5f95f64
     unencrypted_suffix: _unencrypted
-    version: 3.13.2
+    version: 3.13.3


### PR DESCRIPTION
adds some debugging logs to log some of the crashes that i have been having with multi monitor switching. This also adds a stray idrive enablement work, not live upstream because this is a WIP, alongside with the idrive module and pkg that lives in flake-playground.