### PR TITLE
feat/quickshell changes lock part break maybe

### DIFF
--- a/features/hm/wayland/hypr-wl-debug.nix
+++ b/features/hm/wayland/hypr-wl-debug.nix
@@ -8,7 +8,9 @@
 # place the offending request/error pair survives is WAYLAND_DEBUG output, and
 # only if another process is already holding it when quickshell goes. Hence
 # qs-wl-ring (./qs_wl_ring.py): a reader that keeps the tail in memory and
-# flushes on EOF, which is what _exit(1) produces on the pipe.
+# flushes on EOF, which is what _exit(1) produces on the pipe. It writes one
+# file per bar lifetime, because the bar is relaunched within seconds of dying
+# and a single fixed path would have the recovery overwrite the crash.
 #
 # Gated rather than always on, because the trace is tens of thousands of lines
 # a minute and the failure needs a real suspend/resume to reproduce, so it must
@@ -29,6 +31,9 @@
     '';
   };
 
+  # A base path, not the file the trace ends up in: qs-wl-ring derives one
+  # `wl-tail-<stamp>-<pid>.log` per run beside it and keeps this path as a
+  # symlink to the current one.
   defaultLog = "${config.xdg.stateHome}/quickshell/wl-tail.log";
 
   # Its own script rather than an `sh -c` string, so the pipeline lives INSIDE
@@ -108,7 +113,10 @@ in {
       readOnly = true;
       description = ''
         Where the traced session parks the tail of quickshell's WAYLAND_DEBUG
-        output. Overridable at runtime with QS_WL_LOG for a one-off run.
+        output. Symlink to the CURRENT run; each bar lifetime also leaves its own
+        `wl-tail-<UTC start>-<pid>.log` beside it, so a post-crash relaunch
+        cannot overwrite the crash it is recovering from. QS_WL_KEEP (default 10)
+        caps retention. Overridable at runtime with QS_WL_LOG for a one-off run.
       '';
     };
   };

--- a/features/hm/wayland/hypr-wl-debug.nix
+++ b/features/hm/wayland/hypr-wl-debug.nix
@@ -75,11 +75,18 @@
   # The bar's autostart, with exactly one conditional in it. Both branches keep
   # `-s b -a quickshell`, so the shell lands in background-graphical.slice with
   # its memory.low protection either way (nixos/thanatos/memory.nix).
+  #
+  # TEMPORARY: trace on by DEFAULT in every session, hence HYPR_WL_TRACE:-1 and
+  # not the session's HYPR_WL_DEBUG. The fault needs a real suspend/resume that
+  # may be days away, so the trace has to already be running in whatever session
+  # is up when it fires. Revert to `"''${HYPR_WL_DEBUG:-0}"` once the interface
+  # is named. Costs a line per request + ~20 MB of in-memory tail;
+  # HYPR_WL_TRACE=0 opts a session out without a rebuild.
   barLaunch = pkgs.writeShellApplication {
     name = "qs-bar-launch";
     runtimeInputs = [appRun];
     text = ''
-      if [ "''${HYPR_WL_DEBUG:-0}" = "1" ]; then
+      if [ "''${HYPR_WL_TRACE:-1}" = "1" ]; then
         exec app-run -s b -a quickshell ${tracedBar}/bin/qs-bar-traced
       fi
 

--- a/features/hm/wayland/qs_wl_ring.py
+++ b/features/hm/wayland/qs_wl_ring.py
@@ -10,19 +10,59 @@
 # of the evidence on disk. Writes are tmp + rename, so an interrupted snapshot
 # never truncates the previous one.
 #
-# Pure decision helpers live in ring_lines(); ./qs_wl_ring_test.py covers them.
+# ONE FILE PER PRODUCER LIFETIME, not one file overall. The bar is relaunched
+# seconds after it dies, so on a single fixed path the new reader's first
+# snapshot destroys the crash trace before anyone reads it; two crashes in a
+# row left only the second. The name carries the producer's START time (the
+# snapshots need a stable target from line one); crash time is the last line's
+# own timestamp, inside the file. Both UTC. The pid suffix stops two launches
+# in the same second colliding. `<base>` stays a symlink to the current run.
+#
+# Pure decision helpers live in ring_lines(), run_path() and prunable();
+# ./qs_wl_ring_test.py covers them.
 import collections
+import glob
 import os
 import sys
 import time
 
 DEFAULT_LINES = 200000
 SNAPSHOT_SEC = 30
+# A full 200k-line ring is ~14 MB, so this is a ~140 MB ceiling. Raise via
+# QS_WL_KEEP when chasing something that needs a long history of runs.
+DEFAULT_KEEP = 10
 
 
 def ring_lines(lines, limit):
     """The last `limit` items of `lines`, oldest first."""
     return list(collections.deque(lines, maxlen=limit))
+
+
+def run_path(base, stamp, pid):
+    """Per-run log path: `<stem>-<stamp>-<pid><ext>` beside `base`.
+
+    Fixed-width stamp leads, so lexical sort == chronological sort; prunable()
+    relies on that.
+    """
+    stem, ext = os.path.splitext(base)
+    return "%s-%s-%d%s" % (stem, stamp, pid, ext or ".log")
+
+
+def run_glob(base):
+    """Shell glob matching every run file that run_path() can produce."""
+    stem, ext = os.path.splitext(base)
+    return "%s-*-*%s" % (stem, ext or ".log")
+
+
+def prunable(paths, keep):
+    """Which of `paths` to delete so at most `keep` newest remain, oldest first.
+
+    keep <= 0 disables pruning rather than deleting everything: losing the run
+    in progress is the one unrecoverable outcome.
+    """
+    if keep <= 0 or len(paths) <= keep:
+        return []
+    return sorted(paths)[: len(paths) - keep]
 
 
 def dump(ring, path):
@@ -33,9 +73,33 @@ def dump(ring, path):
     os.replace(tmp, path)
 
 
+def link_current(base, target):
+    """Point `base` at `target` (same dir), replacing what was there.
+
+    Symlink not copy: the run file is rewritten every 30s. tmp + os.replace so
+    `base` is never briefly missing; something may be tailing it.
+    """
+    tmp = base + ".link.tmp"
+    if os.path.lexists(tmp):
+        os.remove(tmp)
+    os.symlink(os.path.basename(target), tmp)
+    os.replace(tmp, base)
+
+
 def main(argv):
-    path = argv[1] if len(argv) > 1 else os.path.expanduser("~/qs-wl-tail.log")
+    base = argv[1] if len(argv) > 1 else os.path.expanduser("~/qs-wl-tail.log")
     limit = int(argv[2]) if len(argv) > 2 else DEFAULT_LINES
+    keep = int(os.environ.get("QS_WL_KEEP", DEFAULT_KEEP))
+
+    path = run_path(base, time.strftime("%Y%m%dT%H%M%SZ", time.gmtime()), os.getpid())
+
+    # Create before linking so `base` is never dangling; prune before writing so
+    # the ceiling counts this run.
+    dump([], path)
+    for stale in prunable(glob.glob(run_glob(base)), keep):
+        if stale != path:
+            os.remove(stale)
+    link_current(base, path)
 
     ring = collections.deque(maxlen=limit)
     last = time.monotonic()

--- a/features/hm/wayland/qs_wl_ring_test.py
+++ b/features/hm/wayland/qs_wl_ring_test.py
@@ -47,5 +47,99 @@ class Dump(unittest.TestCase):
             self.assertEqual(sorted(os.listdir(tmp)), ["out.log"])
 
 
+class RunPath(unittest.TestCase):
+    def test_stamp_and_pid_go_before_the_extension(self):
+        self.assertEqual(
+            ring.run_path("/s/wl-tail.log", "20260818T092639Z", 1042677),
+            "/s/wl-tail-20260818T092639Z-1042677.log",
+        )
+
+    def test_extensionless_base_gets_one(self):
+        self.assertEqual(
+            ring.run_path("/s/wl-tail", "20260818T092639Z", 7),
+            "/s/wl-tail-20260818T092639Z-7.log",
+        )
+
+    def test_lexical_order_is_chronological_order(self):
+        # prunable() sorts by name and calls the result oldest-first, which is
+        # only true while the stamp is fixed-width and leads. A pid that sorts
+        # the other way must not be able to reorder two different seconds.
+        early = ring.run_path("/s/t.log", "20260818T092639Z", 999999)
+        late = ring.run_path("/s/t.log", "20260818T092640Z", 1)
+        self.assertLess(early, late)
+
+    def test_glob_matches_run_files_but_not_the_base(self):
+        import fnmatch
+
+        base = "/s/wl-tail.log"
+        pattern = ring.run_glob(base)
+        self.assertTrue(
+            fnmatch.fnmatch(ring.run_path(base, "20260818T092639Z", 7), pattern)
+        )
+        # The base path is the "current run" symlink; pruning must never eat it.
+        self.assertFalse(fnmatch.fnmatch(base, pattern))
+
+
+class Prunable(unittest.TestCase):
+    def test_drops_the_oldest_beyond_the_limit(self):
+        paths = ["t-1.log", "t-2.log", "t-3.log"]
+        self.assertEqual(ring.prunable(paths, 2), ["t-1.log"])
+
+    def test_under_the_limit_keeps_everything(self):
+        self.assertEqual(ring.prunable(["t-1.log"], 5), [])
+
+    def test_unsorted_input_is_ordered_before_slicing(self):
+        # glob() returns directory order, not sorted order.
+        paths = ["t-3.log", "t-1.log", "t-2.log"]
+        self.assertEqual(ring.prunable(paths, 1), ["t-1.log", "t-2.log"])
+
+    def test_zero_keep_deletes_nothing(self):
+        # Deleting every run including the one in progress is the single
+        # unrecoverable outcome, so a nonsense QS_WL_KEEP disables pruning.
+        self.assertEqual(ring.prunable(["t-1.log", "t-2.log"], 0), [])
+        self.assertEqual(ring.prunable(["t-1.log", "t-2.log"], -1), [])
+
+
+class LinkCurrent(unittest.TestCase):
+    def test_points_at_the_run_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "wl-tail.log")
+            target = os.path.join(tmp, "wl-tail-A-1.log")
+            ring.dump(["x\n"], target)
+            ring.link_current(base, target)
+            with open(base) as handle:
+                self.assertEqual(handle.read(), "x\n")
+
+    def test_is_relative_so_the_directory_can_move(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "wl-tail.log")
+            target = os.path.join(tmp, "wl-tail-A-1.log")
+            ring.dump([], target)
+            ring.link_current(base, target)
+            self.assertEqual(os.readlink(base), "wl-tail-A-1.log")
+
+    def test_replaces_an_existing_link(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "wl-tail.log")
+            first = os.path.join(tmp, "wl-tail-A-1.log")
+            second = os.path.join(tmp, "wl-tail-B-2.log")
+            ring.dump(["first\n"], first)
+            ring.dump(["second\n"], second)
+            ring.link_current(base, first)
+            ring.link_current(base, second)
+            with open(base) as handle:
+                self.assertEqual(handle.read(), "second\n")
+
+    def test_leaves_no_tmp_link_behind(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "wl-tail.log")
+            target = os.path.join(tmp, "wl-tail-A-1.log")
+            ring.dump([], target)
+            ring.link_current(base, target)
+            self.assertEqual(
+                sorted(os.listdir(tmp)), ["wl-tail-A-1.log", "wl-tail.log"]
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/features/hm/wayland/quickshell-lock.nix
+++ b/features/hm/wayland/quickshell-lock.nix
@@ -78,7 +78,7 @@ in {
   # is missing or empty, so "workspace" is never a hard dependency on
   # screencopy being available.
   options.quickshellLock.backdrop.mode = lib.mkOption {
-    type = lib.types.enum [ "workspace" "wallpaper" ];
+    type = lib.types.enum ["workspace" "wallpaper"];
     default = "workspace";
     description = ''
       Lock backdrop source: "workspace" (frozen ScreencopyView of the desktop,
@@ -94,7 +94,7 @@ in {
       description = "Show the notification backlog on the lock.";
     };
     defaultMode = lib.mkOption {
-      type = lib.types.enum [ "hidden" "sensitive" "full" ];
+      type = lib.types.enum ["hidden" "sensitive" "full"];
       default = "sensitive";
       description = "Default visibility for the 'default' tier (non-trusted, non-private).";
     };
@@ -111,17 +111,17 @@ in {
     };
     trustedApps = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "blueman" "blueman-applet" "NetworkManager" "org.freedesktop.*" ];
+      default = ["blueman" "blueman-applet" "NetworkManager" "org.freedesktop.*"];
       description = "App names / desktop-entries (glob, '*' only) whose notifications are full + interactive on the lock.";
     };
     privateApps = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ ];
+      default = [];
       description = "App names / desktop-entries (glob) forced to hidden (count-only) on the lock, even when Critical.";
     };
     trustedCategories = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = [ "device" "network" "x-systemd*" "hardware" ];
+      default = ["device" "network" "x-systemd*" "hardware"];
       description = "freedesktop notification categories (glob) treated as trusted.";
     };
   };
@@ -238,7 +238,7 @@ in {
   };
 
   config = {
-    home.packages = [ lockEscape ];
+    home.packages = [lockEscape];
 
     # Config seam the QML LockConfig FileView reads. Outside ~/.config/quickshell
     # (the repo symlink) so it never dirties the repo -- mirrors quickshell-idle.
@@ -288,7 +288,7 @@ in {
         '';
         Restart = "on-failure";
       };
-      Install.WantedBy = [ "graphical-session.target" ];
+      Install.WantedBy = ["graphical-session.target"];
     };
   };
 }

--- a/features/hm/wayland/quickshell-lock.nix
+++ b/features/hm/wayland/quickshell-lock.nix
@@ -1,8 +1,13 @@
 # HM wiring for the Quickshell lock: the Nix-owned config seam (fail-open flag +
 # fallback image), the dev escape-hatch helper, and the watchdog. The QML/PAM
 # live elsewhere (task-bar/lock, features/nixos/auth/pam).
-{ config, lib, pkgs, appRun, ... }:
-let
+{
+  config,
+  lib,
+  pkgs,
+  qsBarLaunch,
+  ...
+}: let
   # Single source of truth for the dev escape hatch (see the option below). Gates
   # the QML startup-escape (via config.json), the watchdog unit, and the Hyprland
   # recovery keybind (hyprland.nix reads config.quickshellLock.failOpenOnCrash).
@@ -10,12 +15,12 @@ let
 
   lockEscape = pkgs.writeShellApplication {
     name = "lock-escape";
-    # appRun so the relaunch resolves app-run hermetically rather than off
-    # whatever PATH the compositor happens to hand the keybind.
+    # qsBarLaunch, not appRun: the relaunch reuses the autostart entry point, so
+    # placement and tracing are decided in one place (hypr-wl-debug.nix).
     # systemd for `systemctl --user show-environment`: the script re-reads the
     # session's live display environment because a unit that started before
     # uwsm finalize has none of its own (see the note in lock-escape.sh).
-    runtimeInputs = [ pkgs.quickshell pkgs.procps pkgs.coreutils pkgs.systemd appRun ];
+    runtimeInputs = [pkgs.quickshell pkgs.procps pkgs.coreutils pkgs.systemd qsBarLaunch];
     text = builtins.readFile ./quickshell/task-bar/lock/lock-escape.sh;
   };
 in {

--- a/features/hm/wayland/quickshell/task-bar/lock/Lock.qml
+++ b/features/hm/wayland/quickshell/task-bar/lock/Lock.qml
@@ -644,7 +644,12 @@ Scope {
     Timer {
         id: releaseTimer
         interval: 200
-        onTriggered: root.locked = false; // unlock_and_destroy -> desktop returns
+        // _release(), not a bare `locked = false`: that drops the compositor
+        // lock but never fires `loginctl unlock-session`, so lock.target stays
+        // active and disarms the NEXT lock -- qs-lock-trigger is
+        // WantedBy=lock.target (../../../swayidle.nix) and systemd will not
+        // re-run it for a target already up.
+        onTriggered: root._release() // unlock_and_destroy + unlock.target
     }
 
     // Marker file for the watchdog (qs-lock-watchdog): present while locked, so

--- a/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
+++ b/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
@@ -27,31 +27,44 @@ CFG="task-bar"
 # the whole block: show-environment emits $'...' shell quoting for values that
 # need it, and blindly exporting those would set the literal text.
 live_env() {
-    # Trailing `|| true` is load-bearing: writeShellApplication runs this under
-    # `set -euo pipefail`, so a systemctl that cannot reach the user manager
-    # would abort lock-escape right here -- silently, and before the explicit
-    # refusal below could say why.
-    systemctl --user show-environment 2>/dev/null | sed -n "s/^$1=//p" | head -1 || true
+  # Trailing `|| true` is load-bearing: writeShellApplication runs this under
+  # `set -euo pipefail`, so a systemctl that cannot reach the user manager
+  # would abort lock-escape right here -- silently, and before the explicit
+  # refusal below could say why.
+  _raw="$(systemctl --user show-environment 2>/dev/null | sed -n "s/^$1=//p" | head -1 || true)"
+  # show-environment ANSI-C-quotes any value with a space, and
+  # UWSM_FINALIZE_VARNAMES always is one. Let the shell undo its own quoting:
+  # the guard restricts eval to a complete $'...' literal, and \' escaping
+  # means the string cannot terminate early.
+  case "$_raw" in
+  \$\'*\') eval "_raw=$_raw" ;;
+  esac
+  printf '%s\n' "$_raw"
 }
 
-for _var in WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_RUNTIME_DIR; do
-    _val="$(live_env "$_var")"
-    if [ -n "$_val" ]; then
-        case "$_var" in
-            WAYLAND_DISPLAY) export WAYLAND_DISPLAY="$_val" ;;
-            HYPRLAND_INSTANCE_SIGNATURE) export HYPRLAND_INSTANCE_SIGNATURE="$_val" ;;
-            XDG_RUNTIME_DIR) export XDG_RUNTIME_DIR="$_val" ;;
-        esac
-    fi
+# UWSM_FINALIZE_VARNAMES: app-run only takes its uwsm branch when this is set
+# (see ../../../app-run.nix). uwsm publishes it to the MANAGER env at finalize,
+# so a unit started before that never has it, app-run degrades to plain exec,
+# and the relaunched bar inherits THIS script's cgroup (qs-lock-watchdog).
+for _var in WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_RUNTIME_DIR UWSM_FINALIZE_VARNAMES; do
+  _val="$(live_env "$_var")"
+  if [ -n "$_val" ]; then
+    case "$_var" in
+    WAYLAND_DISPLAY) export WAYLAND_DISPLAY="$_val" ;;
+    HYPRLAND_INSTANCE_SIGNATURE) export HYPRLAND_INSTANCE_SIGNATURE="$_val" ;;
+    XDG_RUNTIME_DIR) export XDG_RUNTIME_DIR="$_val" ;;
+    UWSM_FINALIZE_VARNAMES) export UWSM_FINALIZE_VARNAMES="$_val" ;;
+    esac
+  fi
 done
-unset _var _val
+unset _var _val _raw
 
 # Without a display there is nothing to unlock and a relaunch would only
 # reproduce the abort above. Fail loudly rather than leaving a silent crash
 # loop in the journal.
 if [ -z "${WAYLAND_DISPLAY:-}" ]; then
-    echo "lock-escape: no WAYLAND_DISPLAY in this process or in the systemd user environment; refusing to relaunch" >&2
-    exit 1
+  echo "lock-escape: no WAYLAND_DISPLAY in this process or in the systemd user environment; refusing to relaunch" >&2
+  exit 1
 fi
 
 # ACQUIRE, THEN RELEASE -- releasing alone is not enough, and that is what

--- a/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
+++ b/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
@@ -77,11 +77,11 @@ fi
 # candidate list instead of acting -- observed with four stale entries.
 shell_pid="$(pgrep -f "quickshell -c $CFG" | head -1 || true)"
 
-if [ -n "$shell_pid" ] \
-    && qs ipc --pid "$shell_pid" call lock lock >/dev/null 2>&1 \
-    && sleep 0.3 \
-    && qs ipc --pid "$shell_pid" call lock unlock >/dev/null 2>&1; then
-    exit 0
+if [ -n "$shell_pid" ] &&
+  qs ipc --pid "$shell_pid" call lock lock >/dev/null 2>&1 &&
+  sleep 0.3 &&
+  qs ipc --pid "$shell_pid" call lock unlock >/dev/null 2>&1; then
+  exit 0
 fi
 
 # Shell unresponsive/dead: ensure it is gone, then relaunch in escape mode.

--- a/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
+++ b/features/hm/wayland/quickshell/task-bar/lock/lock-escape.sh
@@ -103,23 +103,13 @@ fi
 # `quickshell -c task-bar` command line is comm-truncation-proof.
 pkill -f 'quickshell -c task-bar' 2>/dev/null || true
 sleep 0.3
-# Same placement as the autostart hook (hyprland.nix): -s b ASKS for
-# background-graphical.slice so the recovered bar keeps the memory.low
-# protection the normally-started one gets (nixos/thanatos/memory.nix).
+# Relaunch via qs-bar-launch, the same entry point the autostart hook uses
+# (hyprland.nix calls it, hypr-wl-debug.nix builds it). It owns both the
+# `-s b -a quickshell` placement and whether the bar runs under WAYLAND_DEBUG.
+# Re-deriving the app-run line here dropped tracing from the recovery path,
+# i.e. from the one launch whose crash we needed traced.
 #
-# Do not assume it lands there. app-run only takes its uwsm branch when
-# UWSM_FINALIZE_VARNAMES is set, and that comes from uwsm's per-compositor
-# quirks plugin, which uwsm selects by basename(Exec[0]) -- so a session
-# launched through a wrapper gets no plugin, no variable, and app-run silently
-# degrades to plain `exec "$@"`. When that happened the recovered bar simply
-# inherited THIS script's cgroup, i.e. qs-lock-watchdog.service, and a
-# home-manager switch restarting that unit killed the bar with it
-# (KillMode=control-group). Fixed at the source in
-# ../../../../../nixos/desktop/wayland/hyprland-wldebug.nix by naming the
-# wrapper start-hyprland, but the degradation is silent, so treat placement
-# here as best-effort rather than guaranteed.
-# app2unit uses `systemd-run --scope`, which execs in place, so QS_LOCK_ESCAPE
-# is inherited by the scope -- the whole point of this relaunch. The scope name
-# carries a random suffix, so it cannot collide with a stale one.
-QS_LOCK_ESCAPE=1 app-run -s b -a quickshell qs -c "$CFG" >/dev/null 2>&1 &
+# Placement stays best-effort: needs UWSM_FINALIZE_VARNAMES, exported above.
+# app2unit execs in place, so QS_LOCK_ESCAPE reaches the scope.
+QS_LOCK_ESCAPE=1 qs-bar-launch >/dev/null 2>&1 &
 exit 0

--- a/features/nixos/desktop/common/default.nix
+++ b/features/nixos/desktop/common/default.nix
@@ -170,6 +170,7 @@ in {
               --prefix PATH : "${xdg-open-ovr}/bin" \
             '';
           }))
+        vesktop
         # master.armcord.overrideAttrs (_: {
         #   postFixup = ''
         #     # TODO: find a better way of doing this

--- a/helpers/overlays.nix
+++ b/helpers/overlays.nix
@@ -453,9 +453,16 @@
         ];
     });
   };
+  awwwPatched = final: prev: {
+    awww = prev.awww.overrideAttrs (o: {
+      buildInputs = (o.buildInputs or []) ++ [final.dav1d];
+      cargoBuildFeatures = (o.cargoBuildFeatures or []) ++ ["avif"];
+    });
+  };
 
   baseDesktop = [
     quickshellPatched
+    awwwPatched
     inputs.nix-vscode-extensions.overlays.default
     inputs.nix-your-shell.overlays.default
     inputs.rust-overlay.overlays.default

--- a/helpers/overlays.nix
+++ b/helpers/overlays.nix
@@ -228,6 +228,14 @@
           # Unlike the backport above this applies to main too, so it survives a
           # bump and is upstreamable as-is.
           ../overlays/hyprland-capture-source-stale-output.patch
+          # Fourth site, same resume race, and the one that survived the patch
+          # above: get_lock_surface on an output whose monitor is gone returns
+          # WITHOUT constructing anything, stranding the client-allocated new_id.
+          # The kill lands later on that proxy's destroy, as
+          # wl_display.error(0, "invalid object <id>") -- which is why fixing
+          # create_source moved the crash instead of removing it. Still unfixed
+          # on main as of 2026-08-20, so upstreamable rather than a backport.
+          ../overlays/hyprland-session-lock-surface-stale-output.patch
         ];
     });
     # xdg-desktop-portal-hyprland past its v1.4.0 tag, for 71ae1a3a

--- a/nixos/thanatos/game-tdp/game-tdp.sh
+++ b/nixos/thanatos/game-tdp/game-tdp.sh
@@ -13,14 +13,19 @@ MARKER_DIR="${GAME_TDP_MARKER_DIR:-/run/gamemode}"
 AC_ONLINE="${GAME_TDP_AC:-/sys/class/power_supply/AC/online}"
 FAN_MODE="${GAME_TDP_FAN:-/run/thinkfan/mode}"
 OVERRIDE_FILE="${GAME_TDP_OVERRIDE:-/run/gamemode/override}"
-BOOST_W="${GAME_TDP_BOOST_W:-35000}"
-DEFAULT_W="${GAME_TDP_DEFAULT_W:-28000}"
+BOOST_W="${GAME_TDP_BOOST_W:-25000}"
+DEFAULT_W="${GAME_TDP_DEFAULT_W:-23000}"
+
+# Defaults that are well tested
+# BOOST_W="${GAME_TDP_BOOST_W:-25000}"
+# DEFAULT_W="${GAME_TDP_DEFAULT_W:-23000}"
+
 # Battery: game-tdp does NOT drive ryzenadj on battery; it only knocks the limit
 # down ONCE on the AC->battery transition (so a prior boost never persists), then
 # leaves power management to tlp/BIOS. Keep BATTERY_W low + battery-appropriate.
 BATTERY_W="${GAME_TDP_BATTERY_W:-15000}"
-BOOST_TCTL="${GAME_TDP_BOOST_TCTL:-90}"
-DEFAULT_TCTL="${GAME_TDP_DEFAULT_TCTL:-90}"
+BOOST_TCTL="${GAME_TDP_BOOST_TCTL:-95}"
+DEFAULT_TCTL="${GAME_TDP_DEFAULT_TCTL:-95}"
 BATTERY_TCTL="${GAME_TDP_BATTERY_TCTL:-85}"
 
 log() { printf 'game-tdp: %s\n' "$*"; }
@@ -75,8 +80,11 @@ gamemode_clients() {
   owner="$(as_user busctl --user call org.freedesktop.DBus /org/freedesktop/DBus \
     org.freedesktop.DBus NameHasOwner s com.feralinteractive.GameMode 2>/dev/null || true)"
   case "$owner" in
-    *true*) : ;;
-    *) echo 0; return 0 ;;
+  *true*) : ;;
+  *)
+    echo 0
+    return 0
+    ;;
   esac
   as_user busctl --user get-property com.feralinteractive.GameMode \
     /com/feralinteractive/GameMode com.feralinteractive.GameMode ClientCount \
@@ -86,28 +94,28 @@ gamemode_clients() {
 # manual_override: user override written by `game-boost` -> on|off|auto (default).
 manual_override() {
   case "$(cat "$OVERRIDE_FILE" 2>/dev/null)" in
-    on) echo on ;;
-    off) echo off ;;
-    *) echo auto ;;
+  on) echo on ;;
+  off) echo off ;;
+  *) echo auto ;;
   esac
 }
 
 set_fan() { # perf|auto -- mirrors amd.nix fan-mode: write /run/thinkfan/mode
   [ -w "$FAN_MODE" ] || return 0
   case "$1" in
-    perf) printf 'perf\n' >"$FAN_MODE" ;;
-    auto) : >"$FAN_MODE" ;;
+  perf) printf 'perf\n' >"$FAN_MODE" ;;
+  auto) : >"$FAN_MODE" ;;
   esac
 }
 
-ryzen() { # <watts_mW> <tctl_C>
-  ryzenadj --stapm-limit "$1" --fast-limit "$1" --slow-limit "$1" \
-    --apu-slow-limit "$1" --slow-time 5 --tctl-temp "$2" >/dev/null 2>&1 || true
+ryzen() { # <watts_mW> <tctl_C> <boost_mW>
+  ryzenadj --stapm-limit "$1" --fast-limit "$3" --slow-limit "$1" \
+    --apu-slow-limit "$1" --slow-time 5 --tctl-temp "$2" --apu-skin-temp 65 >/dev/null 2>&1 || true
 }
 
-apply_boost() { ryzen "$BOOST_W" "$BOOST_TCTL"; }
-apply_default() { ryzen "$DEFAULT_W" "$DEFAULT_TCTL"; }
-apply_battery() { ryzen "$BATTERY_W" "$BATTERY_TCTL"; }
+apply_boost() { ryzen "$BOOST_W" "$BOOST_TCTL" "$BOOST_W"; }
+apply_default() { ryzen "$DEFAULT_W" "$DEFAULT_TCTL" "$BOOST_W"; }
+apply_battery() { ryzen "$BATTERY_W" "$BATTERY_TCTL" "$BATTERY_W"; }
 
 LAST=""
 reconcile() {
@@ -115,9 +123,9 @@ reconcile() {
   # A manual `game-boost on|off` override wins over gamemode; `auto` (the default)
   # uses the live gamemode client count. Battery still wins in decide() either way.
   case "$(manual_override)" in
-    on) clients=1 ;;
-    off) clients=0 ;;
-    *) clients="$(gamemode_clients)" ;;
+  on) clients=1 ;;
+  off) clients=0 ;;
+  *) clients="$(gamemode_clients)" ;;
   esac
   want="$(decide "$(ac_online)" "$clients")"
   # On AC, actively hold the target every poll (boost can drift; default reverts a
@@ -126,8 +134,8 @@ reconcile() {
   # transition into battery (below) knocks any boost down so it never persists
   # off-charger.
   case "$want" in
-    boost) apply_boost ;;
-    default) apply_default ;;
+  boost) apply_boost ;;
+  default) apply_default ;;
     # battery: intentionally no per-poll ryzenadj (see the transition below)
   esac
   # The fan is shared with the user's `fan-mode` helper, so it is written only on
@@ -135,12 +143,12 @@ reconcile() {
   # The battery transition also performs the one-time ryzenadj back-off.
   if [ "$want" != "$LAST" ]; then
     case "$want" in
-      boost) set_fan perf ;;
-      battery)
-        apply_battery
-        set_fan auto
-        ;;
-      *) set_fan auto ;;
+    boost) set_fan perf ;;
+    battery)
+      apply_battery
+      set_fan auto
+      ;;
+    *) set_fan auto ;;
     esac
     log "$want"
     LAST="$want"
@@ -159,16 +167,16 @@ run() {
 
 if [ "${GAME_TDP_TEST:-0}" != "1" ]; then
   case "${1:-run}" in
-    run) run ;;
-    revert)
-      # undo any boost with the AC-appropriate non-boost profile
-      if [ "$(ac_online)" = "1" ]; then apply_default; else apply_battery; fi
-      set_fan auto
-      log "revert"
-      ;;
-    *)
-      echo "usage: game-tdp [run|revert]" >&2
-      exit 2
-      ;;
+  run) run ;;
+  revert)
+    # undo any boost with the AC-appropriate non-boost profile
+    if [ "$(ac_online)" = "1" ]; then apply_default; else apply_battery; fi
+    set_fan auto
+    log "revert"
+    ;;
+  *)
+    echo "usage: game-tdp [run|revert]" >&2
+    exit 2
+    ;;
   esac
 fi

--- a/overlays/hyprland-session-lock-surface-stale-output.patch
+++ b/overlays/hyprland-session-lock-surface-stale-output.patch
@@ -1,0 +1,102 @@
+protocols/session-lock: hand out an inert lock surface, never strand the id
+
+A Wayland new_id is client-allocated and unconfirmed, so a handler that returns
+without constructing anything leaves the client holding a proxy for an id the
+compositor does not know. The client is killed on its next request to that
+proxy, normally destroy:
+
+  -> ext_session_lock_v1#520.get_lock_surface(new id #550, #540, wl_output#544)
+     [onGetLockSurface: monitor is gone for output resource -> returns]
+     wl_registry#2.global_remove(75)          <- 65us AFTER the request
+  -> ext_session_lock_surface_v1#550.destroy()
+     wl_display#1.error(wl_display#1, 0, "invalid object 550")
+
+wl_registry.global_remove says requests to a removed global "will be ignored",
+i.e. ignore the EFFECT, not skip constructing the object the request allocates.
+Three sites strand an id: the m_inert branch of setGetLockSurface, and both
+early returns in onGetLockSurface. Construct with a null monitor instead;
+CSessionLockSurface already tolerates one everywhere except the commit
+listener, guarded here.
+
+--- a/src/protocols/SessionLock.cpp
++++ b/src/protocols/SessionLock.cpp
+@@ -25,6 +25,12 @@
+     m_resource->setAckConfigure([this](CExtSessionLockSurfaceV1* r, uint32_t serial) { m_ackdConfigure = true; });
+ 
+     m_listeners.surfaceCommit = m_surface->m_events.commit.listen([this] {
++        // Inert surface (null monitor, see onGetLockSurface): never got a
++        // configure, so never ackd one, so every commit would take the
++        // COMMIT_BEFORE_FIRST_ACK path below and kill the client.
++        if (!m_monitor)
++            return;
++
+         if (!m_surface->m_current.texture) {
+             LOGM(Log::ERR, "SessionLock attached a null buffer");
+             m_resource->error(EXT_SESSION_LOCK_SURFACE_V1_ERROR_NULL_BUFFER, "Null buffer attached");
+@@ -111,11 +117,8 @@
+     m_resource->setOnDestroy([this](CExtSessionLockV1* r) { PROTO::sessionLock->destroyResource(this); });
+ 
+     m_resource->setGetLockSurface([this](CExtSessionLockV1* r, uint32_t id, wl_resource* surf, wl_resource* output) {
+-        if (m_inert) {
+-            LOGM(Log::ERR, "Lock is trying to send getLockSurface after it's inert");
+-            return;
+-        }
+-
++        // No early return on m_inert: `id` is already spent by the client.
++        // onGetLockSurface reads m_inert itself and hands back an inert surface.
+         PROTO::sessionLock->onGetLockSurface(r, id, surf, output);
+     });
+ 
+@@ -203,17 +206,17 @@
+ void CSessionLockProtocol::onGetLockSurface(CExtSessionLockV1* lock, uint32_t id, wl_resource* surface, wl_resource* output) {
+     LOGM(Log::DEBUG, "New sessionLockSurface with id {}", id);
+ 
+-    auto PSURFACE  = CWLSurfaceResource::fromResource(surface);
+-    auto OUTPUTRES = CWLOutputResource::fromResource(output);
+-    if (!OUTPUTRES) {
+-        LOGM(Log::ERR, "onGetLockSurface: invalid output resource");
+-        return;
+-    }
+-    auto PMONITOR = OUTPUTRES->m_monitor.lock();
+-    if (!PMONITOR) {
+-        LOGM(Log::ERR, "onGetLockSurface: monitor is gone for output resource");
+-        return;
+-    }
++    auto       PSURFACE  = CWLSurfaceResource::fromResource(surface);
++    auto       OUTPUTRES = CWLOutputResource::fromResource(output);
++
++    // Gone monitor means INERT, not "skip construction": the client already
++    // allocated `id` and must get an object back either way.
++    PHLMONITOR PMONITOR = OUTPUTRES ? OUTPUTRES->m_monitor.lock() : nullptr;
++
++    if (!OUTPUTRES)
++        LOGM(Log::ERR, "onGetLockSurface: invalid output resource, handing out an inert lock surface");
++    else if (!PMONITOR)
++        LOGM(Log::ERR, "onGetLockSurface: monitor is gone for output resource, handing out an inert lock surface");
+ 
+     SP<CSessionLock> sessionLock;
+     for (auto const& l : m_locks) {
+@@ -223,6 +226,10 @@
+         }
+     }
+ 
++    // Same for an already-inert lock, or one the lookup above missed.
++    if (!sessionLock || sessionLock->m_inert)
++        PMONITOR = nullptr;
++
+     const auto RESOURCE =
+         m_lockSurfaces.emplace_back(makeShared<CSessionLockSurface>(makeShared<CExtSessionLockSurfaceV1>(lock->client(), lock->version(), id), PSURFACE, PMONITOR, sessionLock));
+ 
+@@ -232,6 +239,12 @@
+         return;
+     }
+ 
++    // Keep inert surfaces out of the render path: CSessionLockManager's
++    // newSurface listener derefs surface->monitor() unconditionally. The emit
++    // was also a latent null deref when the m_locks lookup missed.
++    if (!PMONITOR || !sessionLock)
++        return;
++
+     sessionLock->m_events.newLockSurface.emit(RESOURCE);
+ }
+ 

--- a/pkgs/hypr-lock-strand-repro/README.md
+++ b/pkgs/hypr-lock-strand-repro/README.md
@@ -1,0 +1,158 @@
+# hypr-lock-strand-repro
+
+Detects a Wayland compositor that returns from
+`ext_session_lock_v1.get_lock_surface` without creating an object for the
+client-allocated `new_id`.
+
+```
+nix run .
+```
+
+Exit codes: `0` survived (not affected), `1` killed (affected), `2` skipped
+(preconditions unmet, nothing proven), `3` error.
+
+## What it is checking
+
+A Wayland `new_id` is allocated by the **client** and never acknowledged. The
+client picks the number, sends the request, and from that moment treats the
+object as existing. A compositor that declines to construct it leaves the
+client holding a proxy for an id the compositor has never heard of, and does
+not say so.
+
+Nothing breaks at that point. It breaks on the next request to that proxy,
+normally `destroy`, when `libwayland-server` cannot resolve the id and posts
+`wl_display.error(0, "invalid object N")`. Protocol errors are fatal.
+
+This tool drives that path on purpose:
+
+1. take a session lock; the compositor grants it
+2. ask for a second lock; a conforming compositor denies it and sends
+   `finished`
+3. call `get_lock_surface` on the **denied** lock, spending an id
+4. unlock and restore the screen
+5. destroy the denied lock (legal: `destroy` is only an error if `locked` was
+   sent, and it was not)
+6. destroy the id from step 3, and report which way it went
+
+Step 4 happens before step 6 on purpose: if the compositor kills us at step 6,
+the session is already unlocked.
+
+## Safety
+
+The session is locked for a fraction of a second and unlocked again before the
+request under test is sent. The tool never reads input and never
+authenticates. During the locked window the compositor shows its own fallback
+surface, because this client deliberately draws nothing.
+
+The residual risk is the ordinary one for any session-lock client: if the
+process is killed between steps 1 and 4, the compositor keeps the session
+locked with no client to unlock it. That is what `ext-session-lock-v1` is
+designed to do. Recovery is a VT switch, or a second client permitted to
+assume the orphaned lock.
+
+## Preconditions
+
+The compositor must **deny** a second concurrent session lock, which is the
+default. On Hyprland that means:
+
+```
+misc:allow_session_lock_restore = false
+```
+
+With it enabled, Hyprland neither grants nor denies the second lock, the code
+path under test is never entered, and the tool reports `SKIPPED` rather than
+guessing. Check the live value with:
+
+```
+hyprctl getoption misc:allow_session_lock_restore
+```
+
+## Expected results
+
+| Compositor | Expected |
+| --- | --- |
+| Hyprland through v0.56.2, unpatched | `KILLED` |
+| Hyprland with the session-lock patch applied | `SURVIVED` |
+| sway, or anything else on wlroots | `SURVIVED` |
+| A compositor with no ext-session-lock-v1 | `SKIPPED` |
+
+wlroots is unaffected because it creates the object before validating
+anything and leaves it inert. Its own comment says so:
+
+```c
+	// We always need to create a lock surface resource to stay in sync
+	// with the client, even if the lock resource or output resource is
+	// inert. For example, if the compositor denies the lock and immediately
+	// calls wlr_session_lock_v1_destroy() the client may have already sent
+	// get_lock_surface requests.
+```
+
+That example is precisely the case this tool exercises.
+
+## Verification status
+
+Be precise about this when quoting results anywhere.
+
+- **Builds clean.** `-Wall -Wextra -Werror`, and the derivation's
+  `installCheckPhase` runs `--help`.
+- **Runtime behaviour is unverified.** As of writing, the program has not been
+  executed against any compositor. Nobody has yet seen it print `KILLED` or
+  `SURVIVED`.
+
+Do not describe it as a confirmed reproducer until someone has run it. If you
+run it, record the compositor, its version, the value of
+`misc:allow_session_lock_restore`, and the full stdout and stderr. The
+compositor's own message, naming the stranded id, arrives on **stderr** via
+libwayland's logging, not on stdout.
+
+## Testing without risking a real session
+
+Run it against a nested compositor instead of your desktop:
+
+```
+# terminal 1: a throwaway Hyprland in a window, with the precondition set
+Hyprland -c /path/to/minimal.conf     # containing misc:allow_session_lock_restore = false
+
+# terminal 2: point the tool at the nested instance
+WAYLAND_DISPLAY=wayland-2 nix run .
+```
+
+The nested instance uses aquamarine's Wayland backend and is just a window, so
+a stranded lock there costs nothing. Confirm the display name from the nested
+compositor's startup output rather than assuming `wayland-2`.
+
+## Consuming this from another flake
+
+`default.nix` takes plain `callPackage` arguments and has no dependency on the
+wrapper flake, so a host repo can do:
+
+```nix
+hypr-lock-strand-repro = pkgs.callPackage ./pkgs/hypr-lock-strand-repro {};
+```
+
+Dependencies are `wayland`, `wayland-scanner`, `wayland-protocols` and
+`pkg-config`. The protocol bindings are generated at build time from the
+`wayland-protocols` in scope rather than vendored, so the tool follows whatever
+version the host repo pins.
+
+`flake.nix` exists only so the directory can be copied somewhere and run
+directly. Delete it if you are vendoring the package.
+
+## Background
+
+The defect this detects was found on Hyprland v0.56.2 in August 2026, from a
+`WAYLAND_DEBUG` capture of a lock screen dying on resume:
+
+```
+[08:48:13.650896]  -> ext_session_lock_v1#520.get_lock_surface(
+                        new id ext_session_lock_surface_v1#550,
+                        wl_surface#540, wl_output#544)
+[08:48:13.650961]     wl_registry#2.global_remove(75)
+[08:48:14.095661]  -> ext_session_lock_surface_v1#550.destroy()
+[08:48:14.104302]     wl_display#1.error(wl_display#1, 0, "invalid object 550")
+```
+
+The client sent the request 65 microseconds before being told the output was
+gone, so it could not have avoided it. Three code paths in
+`src/protocols/SessionLock.cpp` strand an id this way. This tool exercises the
+one that needs no hardware and no race.

--- a/pkgs/hypr-lock-strand-repro/default.nix
+++ b/pkgs/hypr-lock-strand-repro/default.nix
@@ -1,0 +1,91 @@
+# Reproducer for a compositor that strands a client-allocated new_id in
+# ext_session_lock_v1.get_lock_surface. See ./README.md.
+#
+# Depends only on wayland + wayland-protocols, so it runs against any
+# compositor, not just the one it was written for.
+{
+  lib,
+  stdenv,
+  pkg-config,
+  wayland,
+  wayland-scanner,
+  wayland-protocols,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hypr-lock-strand-repro";
+  version = "1.0.0";
+
+  # Only what the build reads: keeps README/flake edits from forcing a rebuild.
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./strand.c
+    ];
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [pkg-config wayland-scanner];
+  buildInputs = [wayland];
+
+  # Bindings generated at build time from wayland-protocols, not vendored, so
+  # the tool tracks whatever version nixpkgs carries.
+  protocolXml = "${wayland-protocols}/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml";
+
+  buildPhase = ''
+    runHook preBuild
+
+    test -f "$protocolXml" || {
+      echo "ext-session-lock-v1.xml not found at $protocolXml" >&2
+      exit 1
+    }
+
+    wayland-scanner private-code  "$protocolXml" ext-session-lock-v1-protocol.c
+    wayland-scanner client-header "$protocolXml" ext-session-lock-v1-client-protocol.h
+
+    # -Werror on purpose: a warning means the bindings changed shape under us.
+    $CC -o hypr-lock-strand-repro \
+      strand.c ext-session-lock-v1-protocol.c \
+      -Wall -Wextra -Werror -O2 \
+      $(pkg-config --cflags --libs wayland-client)
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 hypr-lock-strand-repro $out/bin/hypr-lock-strand-repro
+    runHook postInstall
+  '';
+
+  # Cheap ELF sanity check; the real check needs a live compositor.
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/hypr-lock-strand-repro --help > /dev/null
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Detect a Wayland compositor that strands a client-allocated ext_session_lock_surface_v1 id";
+    longDescription = ''
+      ext_session_lock_v1.get_lock_surface carries a new_id, which in Wayland is
+      allocated by the client and never acknowledged. A compositor that returns
+      from the handler without constructing an object leaves the client holding
+      a proxy for an id the compositor has never heard of, and the client is
+      killed with wl_display.error(0, "invalid object N") on its next request to
+      that proxy, which is usually destroy.
+
+      This tool drives that path on purpose and reports SURVIVED or KILLED. It
+      locks and unlocks the session before issuing the request under test, so a
+      kill cannot strand the session.
+
+      Affects Hyprland through at least v0.56.2. wlroots-based compositors,
+      including sway, are unaffected: wlroots creates the object before
+      validating anything and leaves it inert.
+    '';
+    homepage = "https://github.com/hyprwm/Hyprland";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.linux;
+    mainProgram = "hypr-lock-strand-repro";
+  };
+})

--- a/pkgs/hypr-lock-strand-repro/flake.lock
+++ b/pkgs/hypr-lock-strand-repro/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/pkgs/hypr-lock-strand-repro/flake.nix
+++ b/pkgs/hypr-lock-strand-repro/flake.nix
@@ -1,0 +1,44 @@
+# Standalone wrapper so this directory can be copied anywhere and run with
+#
+#   nix run .
+#
+# The package itself is ./default.nix and takes plain callPackage arguments, so
+# a host repo can consume it directly and ignore this file.
+{
+  description = "Detect a Wayland compositor that strands a client-allocated ext_session_lock_surface_v1 id";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    # No flake-utils input: one fewer thing to pin for a single-file tool.
+    systems = ["x86_64-linux" "aarch64-linux"];
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+  in {
+    packages = forAllSystems (pkgs: rec {
+      hypr-lock-strand-repro = pkgs.callPackage ./default.nix {};
+      default = hypr-lock-strand-repro;
+    });
+
+    # `nix run` resolves this through meta.mainProgram, but naming it explicitly
+    # keeps `nix run .#check` working if more entry points get added later.
+    apps = forAllSystems (pkgs: rec {
+      hypr-lock-strand-repro = {
+        type = "app";
+        program = nixpkgs.lib.getExe self.packages.${pkgs.stdenv.hostPlatform.system}.hypr-lock-strand-repro;
+      };
+      default = hypr-lock-strand-repro;
+    });
+
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        packages = [pkgs.wayland pkgs.wayland-scanner pkgs.wayland-protocols pkgs.pkg-config];
+      };
+    });
+
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+  };
+}

--- a/pkgs/hypr-lock-strand-repro/strand.c
+++ b/pkgs/hypr-lock-strand-repro/strand.c
@@ -1,0 +1,237 @@
+/* hypr-lock-strand-repro
+ *
+ * Detects a compositor that returns from ext_session_lock_v1.get_lock_surface
+ * without creating an object for the client-allocated new_id. The client is
+ * then holding a proxy the server does not know, and dies on its next request
+ * to it: wl_display.error(0, "invalid object N"), which is fatal.
+ *
+ * Locks and unlocks the session BEFORE the request under test, so a kill
+ * cannot leave the session locked. Never reads input, never authenticates.
+ *
+ * exit: 0 survived, 1 killed, 2 skipped (preconditions unmet), 3 error
+ */
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wayland-client.h>
+
+#include "ext-session-lock-v1-client-protocol.h"
+
+#define EXIT_SURVIVED 0
+#define EXIT_KILLED   1
+#define EXIT_SKIPPED  2
+#define EXIT_ERROR    3
+
+static struct wl_compositor              *compositor;
+static struct ext_session_lock_manager_v1 *lock_manager;
+static struct wl_output                   *output;
+
+/* Per-lock state, so one listener serves both lock objects. */
+struct lock_state {
+    bool locked;
+    bool finished;
+};
+
+static void on_locked(void *data, struct ext_session_lock_v1 *lock) {
+    (void)lock;
+    ((struct lock_state *)data)->locked = true;
+}
+
+static void on_finished(void *data, struct ext_session_lock_v1 *lock) {
+    (void)lock;
+    ((struct lock_state *)data)->finished = true;
+}
+
+static const struct ext_session_lock_v1_listener lock_listener = {
+    .locked   = on_locked,
+    .finished = on_finished,
+};
+
+static uint32_t min_u32(uint32_t a, uint32_t b) {
+    return a < b ? a : b;
+}
+
+static void reg_global(void *data, struct wl_registry *reg, uint32_t name,
+                       const char *iface, uint32_t ver) {
+    (void)data;
+    if (strcmp(iface, wl_compositor_interface.name) == 0) {
+        compositor = wl_registry_bind(reg, name, &wl_compositor_interface, min_u32(ver, 4));
+    } else if (strcmp(iface, ext_session_lock_manager_v1_interface.name) == 0) {
+        lock_manager = wl_registry_bind(reg, name, &ext_session_lock_manager_v1_interface, 1);
+    } else if (strcmp(iface, wl_output_interface.name) == 0 && output == NULL) {
+        output = wl_registry_bind(reg, name, &wl_output_interface, min_u32(ver, 3));
+    }
+}
+
+static void reg_remove(void *data, struct wl_registry *reg, uint32_t name) {
+    (void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener reg_listener = {
+    .global        = reg_global,
+    .global_remove = reg_remove,
+};
+
+/* Round-trip; describe a protocol error if one killed us. 0 = keep going. */
+static int settle(struct wl_display *dpy, const char *stage) {
+    if (wl_display_roundtrip(dpy) >= 0)
+        return 0;
+
+    int err = wl_display_get_error(dpy);
+    if (err != EPROTO) {
+        printf("RESULT: ERROR\n");
+        printf("  stage = %s\n", stage);
+        printf("  errno = %d (%s)\n", err, strerror(err));
+        return EXIT_ERROR;
+    }
+
+    const struct wl_interface *iface = NULL;
+    uint32_t                   id    = 0;
+    uint32_t                   code  = wl_display_get_protocol_error(dpy, &iface, &id);
+
+    printf("RESULT: KILLED by protocol error\n");
+    printf("  stage        = %s\n", stage);
+    printf("  interface    = %s\n", iface && iface->name ? iface->name : "(unknown)");
+    printf("  object id    = %u\n", id);
+    printf("  error code   = %u", code);
+    if (iface && iface->name && strcmp(iface->name, "wl_display") == 0 && code == 0)
+        printf("   (wl_display.error.invalid_object)");
+    printf("\n");
+    printf("\n");
+    printf("  libwayland logged the compositor's message to stderr above; it\n");
+    printf("  names the stranded id, e.g. \"invalid object 550\".\n");
+    return EXIT_KILLED;
+}
+
+static void usage(const char *argv0) {
+    printf("usage: %s [--help]\n", argv0);
+    printf("\n");
+    printf("Checks whether this Wayland compositor strands a client-allocated\n");
+    printf("object id when ext_session_lock_v1.get_lock_surface cannot be\n");
+    printf("honoured.\n");
+    printf("\n");
+    printf("Requires a compositor that denies a second concurrent session lock,\n");
+    printf("which is the default. On Hyprland that means\n");
+    printf("  misc:allow_session_lock_restore = false\n");
+    printf("With it enabled the second lock is neither granted nor denied and\n");
+    printf("this check cannot run; it reports SKIPPED rather than guessing.\n");
+    printf("\n");
+    printf("The session is locked and unlocked again before the request under\n");
+    printf("test is sent. Exit: 0 survived, 1 killed, 2 skipped, 3 error.\n");
+}
+
+int main(int argc, char **argv) {
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            usage(argv[0]);
+            return EXIT_SURVIVED;
+        }
+        fprintf(stderr, "unknown argument: %s\n", argv[i]);
+        usage(argv[0]);
+        return EXIT_ERROR;
+    }
+
+    struct wl_display *dpy = wl_display_connect(NULL);
+    if (!dpy) {
+        printf("RESULT: ERROR\n");
+        printf("  cannot connect to a Wayland display (is WAYLAND_DISPLAY set?)\n");
+        return EXIT_ERROR;
+    }
+
+    struct wl_registry *reg = wl_display_get_registry(dpy);
+    wl_registry_add_listener(reg, &reg_listener, NULL);
+    if (wl_display_roundtrip(dpy) < 0) {
+        printf("RESULT: ERROR\n  registry round-trip failed\n");
+        return EXIT_ERROR;
+    }
+
+    if (!compositor || !output) {
+        printf("RESULT: ERROR\n  compositor did not advertise wl_compositor and wl_output\n");
+        return EXIT_ERROR;
+    }
+    if (!lock_manager) {
+        printf("RESULT: SKIPPED\n");
+        printf("  this compositor does not implement ext-session-lock-v1\n");
+        return EXIT_SKIPPED;
+    }
+
+    /* 1. Take the lock. The compositor grants this one. */
+    struct lock_state st1 = {0};
+    struct ext_session_lock_v1 *lock1 = ext_session_lock_manager_v1_lock(lock_manager);
+    ext_session_lock_v1_add_listener(lock1, &lock_listener, &st1);
+    int rc = settle(dpy, "first lock");
+    if (rc)
+        return rc;
+
+    if (!st1.locked) {
+        printf("RESULT: SKIPPED\n");
+        printf("  the compositor did not grant the first lock%s\n",
+               st1.finished ? " (it sent finished)" : "");
+        printf("  something else may already hold a session lock\n");
+        return EXIT_SKIPPED;
+    }
+
+    /* 2. Ask again. A conforming compositor denies it and sends finished
+     *    immediately; Hyprland marks that lock m_inert. */
+    struct lock_state st2 = {0};
+    struct ext_session_lock_v1 *lock2 = ext_session_lock_manager_v1_lock(lock_manager);
+    ext_session_lock_v1_add_listener(lock2, &lock_listener, &st2);
+    rc = settle(dpy, "second lock");
+    if (rc)
+        return rc;
+
+    if (!st2.finished) {
+        /* Put the screen back before bailing out. */
+        ext_session_lock_v1_unlock_and_destroy(lock1);
+        wl_display_roundtrip(dpy);
+        printf("RESULT: SKIPPED\n");
+        printf("  the second lock was neither denied nor granted, so the code\n");
+        printf("  path under test was never entered.\n");
+        printf("  on Hyprland: set misc:allow_session_lock_restore = false\n");
+        return EXIT_SKIPPED;
+    }
+
+    /* 3. Lock surface on the DENIED lock. The id is spent here; a compositor
+     *    that returns without constructing has now silently desynced. */
+    struct wl_surface *surface = wl_compositor_create_surface(compositor);
+    struct ext_session_lock_surface_v1 *ls =
+        ext_session_lock_v1_get_lock_surface(lock2, surface, output);
+    uint32_t ls_id = wl_proxy_get_id((struct wl_proxy *)ls);
+    printf("allocated ext_session_lock_surface_v1 id %u on the denied lock\n", ls_id);
+
+    /* 4. Restore the screen before the request under test. */
+    ext_session_lock_v1_unlock_and_destroy(lock1);
+    rc = settle(dpy, "unlocking");
+    if (rc)
+        return rc;
+
+    /* 5. Legal: destroy is only an error if `locked` was sent, and it was not.
+     *    Objects created through the lock "remain valid" after it. */
+    ext_session_lock_v1_destroy(lock2);
+    rc = settle(dpy, "destroying the denied lock");
+    if (rc)
+        return rc;
+
+    /* 6. Touch the possibly-stranded id. This is the whole test. */
+    printf("destroying id %u ...\n", ls_id);
+    fflush(stdout);
+    ext_session_lock_surface_v1_destroy(ls);
+
+    rc = settle(dpy, "destroying the lock surface");
+    if (rc)
+        return rc;
+
+    printf("RESULT: SURVIVED\n");
+    printf("  the compositor created an object for id %u, so destroying it was\n", ls_id);
+    printf("  harmless. This compositor is not affected.\n");
+
+    wl_surface_destroy(surface);
+    wl_display_disconnect(dpy);
+    return EXIT_SURVIVED;
+}


### PR DESCRIPTION
- **style(hm/wayland): apply alejandra and shfmt**
- **fix(hyprland): hand out inert lock surfaces instead of stranding the id**
- **fix(lock): release via \_release() so unlock.target fires**
- **fix(lock-escape): rescue UWSM_FINALIZE_VARNAMES from the manager env**
- **refactor(lock-escape): relaunch via qs-bar-launch**
- **feat(qs-wl-ring): one trace file per producer lifetime**
- **feat(hypr-wl-debug): trace the bar by default in every session**
- **feat(pkgs): add hypr-lock-strand-repro**
- **feat(desktop): add vesktop**
- **feat(overlays): build awww with avif support**
- **change(game-tdp): drop sustained TDP to spec, decouple fast-limit**
